### PR TITLE
[WiP] Speed up dashboard loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ script:
 branches:
   only:
     - master
+cache:
+    npm: false

--- a/app/src/js/components/dashboard_init.tsx
+++ b/app/src/js/components/dashboard_init.tsx
@@ -7,7 +7,7 @@ import Dashboard, { DashboardContents } from './dashboard'
 /**
  * This function post requests to backend to retrieve dashboard contents
  */
-export function initDashboard (vendor?: boolean) {
+export function initDashboard (maxTaskIndex: number, vendor?: boolean) {
   let dashboardContents: DashboardContents
   const xhr = new XMLHttpRequest()
   xhr.onreadystatechange = () => {
@@ -20,6 +20,7 @@ export function initDashboard (vendor?: boolean) {
         </MuiThemeProvider>
         , document.getElementById(vendor ? 'vendor-root'
           : 'dashboard-root'))
+      initDashboard(-1) // load full dashboard after first 1000 elements
     }
   }
   // get params from url path.
@@ -27,7 +28,8 @@ export function initDashboard (vendor?: boolean) {
   const projectName = searchParams.get('project_name')
   // send the request to the back end
   const request = JSON.stringify({
-    name: projectName
+    name: projectName,
+    maxIndex: maxTaskIndex
   })
   xhr.open('POST', './postDashboardContents')
   xhr.setRequestHeader('Content-Type', 'application/json')

--- a/app/src/js/entries/dashboard.tsx
+++ b/app/src/js/entries/dashboard.tsx
@@ -1,3 +1,3 @@
 import { initDashboard } from '../components/dashboard_init'
 
-initDashboard()
+initDashboard(200)

--- a/app/src/js/entries/vendor.tsx
+++ b/app/src/js/entries/vendor.tsx
@@ -1,3 +1,3 @@
 import { initDashboard } from '../components/dashboard_init'
 
-initDashboard(true)
+initDashboard(-1, true)

--- a/app/src/js/server/listeners.ts
+++ b/app/src/js/server/listeners.ts
@@ -153,6 +153,7 @@ export async function DashboardHandler (req: Request, res: Response) {
   if (body) {
     try {
       const name = body.name
+      const maxIndex = body.maxIndex
       const key = getProjectKey(name)
       const fields = await Session.getStorage().load(key)
       const project = JSON.parse(fields) as types.Project
@@ -169,7 +170,11 @@ export async function DashboardHandler (req: Request, res: Response) {
       }
 
       const taskOptions = []
-      for (const emptyTask of tasks) {
+      let slicedTasks = tasks
+      if (maxIndex > 0) {
+        slicedTasks = slicedTasks.slice(0, maxIndex)
+      }
+      for (const emptyTask of slicedTasks) {
         let task
         try {
           // first, attempt loading previous submission


### PR DESCRIPTION
This is a temporary solution that loads 200 of the items first, then loads the remainder afterwards. A better solution would have to change the dashboard rendering, because when there are many items, a large part of the loading time is spent rendering.