### PR TITLE
Commit camera to state only when user action ends

### DIFF
--- a/app/src/js/action/point_cloud.ts
+++ b/app/src/js/action/point_cloud.ts
@@ -5,9 +5,12 @@ import { PointCloudViewerConfigType, ViewerConfigType } from '../functional/type
 import { Vector3D } from '../math/vector3d'
 import * as types from './types'
 
-export const MOUSE_CORRECTION_FACTOR = 60.0
-export const MOVE_AMOUNT = 0.15
-export const ZOOM_SPEED = 1.05
+export enum CameraMovementParameters {
+  MOUSE_CORRECTION_FACTOR = 60.0,
+  MOVE_AMOUNT = 0.15,
+  ZOOM_SPEED = 1.05
+}
+
 export enum CameraLockState {
   UNLOCKED = 0,
   X_LOCKED = 1,
@@ -89,9 +92,9 @@ export function zoomCamera (
     // Decrease distance from origin by amount specified
   let newRadius = spherical.radius
   if (deltaY > 0) {
-    newRadius *= ZOOM_SPEED
+    newRadius *= CameraMovementParameters.ZOOM_SPEED
   } else {
-    newRadius /= ZOOM_SPEED
+    newRadius /= CameraMovementParameters.ZOOM_SPEED
   }
     // Limit zoom to not be too close
   if (newRadius > 0.1 && newRadius < 500) {
@@ -146,8 +149,10 @@ export function rotateCamera (
   spherical.setFromVector3(offset)
 
   // Apply rotations
-  spherical.theta += (newX - initialX) / MOUSE_CORRECTION_FACTOR
-  spherical.phi += (newY - initialY) / MOUSE_CORRECTION_FACTOR
+  spherical.theta +=
+    (newX - initialX) / CameraMovementParameters.MOUSE_CORRECTION_FACTOR
+  spherical.phi +=
+    (newY - initialY) / CameraMovementParameters.MOUSE_CORRECTION_FACTOR
 
   spherical.phi = Math.max(0, Math.min(Math.PI, spherical.phi))
 
@@ -179,8 +184,8 @@ export function dragCamera (
   viewerConfig: PointCloudViewerConfigType
 ): types.ChangeViewerConfigAction {
   const dragVector = new THREE.Vector3(
-    (initialX - newX) / MOUSE_CORRECTION_FACTOR * 2,
-    (newY - initialY) / MOUSE_CORRECTION_FACTOR * 2,
+    (initialX - newX) / CameraMovementParameters.MOUSE_CORRECTION_FACTOR * 2,
+    (newY - initialY) / CameraMovementParameters.MOUSE_CORRECTION_FACTOR * 2,
     0
   )
   dragVector.applyQuaternion(camera.quaternion)
@@ -213,12 +218,12 @@ export function moveUp (
     new Vector3D(
       viewerConfig.position.x,
       viewerConfig.position.y,
-      viewerConfig.position.z + MOVE_AMOUNT
+      viewerConfig.position.z + CameraMovementParameters.MOVE_AMOUNT
     ),
     new Vector3D(
       viewerConfig.target.x,
       viewerConfig.target.y,
-      viewerConfig.target.z + MOVE_AMOUNT
+      viewerConfig.target.z + CameraMovementParameters.MOVE_AMOUNT
     ),
     viewerId,
     viewerConfig
@@ -237,12 +242,12 @@ export function moveDown (
     new Vector3D(
       viewerConfig.position.x,
       viewerConfig.position.y,
-      viewerConfig.position.z - MOVE_AMOUNT
+      viewerConfig.position.z - CameraMovementParameters.MOVE_AMOUNT
     ),
     new Vector3D(
       viewerConfig.target.x,
       viewerConfig.target.y,
-      viewerConfig.target.z - MOVE_AMOUNT
+      viewerConfig.target.z - CameraMovementParameters.MOVE_AMOUNT
     ),
     viewerId,
     viewerConfig
@@ -260,8 +265,8 @@ function calculateForward (
   let forwardX = viewerConfig.target.x - viewerConfig.position.x
   let forwardY = viewerConfig.target.y - viewerConfig.position.y
   const forwardDist = Math.sqrt(forwardX * forwardX + forwardY * forwardY)
-  forwardX *= MOVE_AMOUNT / forwardDist
-  forwardY *= MOVE_AMOUNT / forwardDist
+  forwardX *= CameraMovementParameters.MOVE_AMOUNT / forwardDist
+  forwardY *= CameraMovementParameters.MOVE_AMOUNT / forwardDist
   return new THREE.Vector3(forwardX, forwardY, 0)
 }
 
@@ -335,7 +340,7 @@ function calculateLeft (
   const left = new THREE.Vector3()
   left.crossVectors(vertical, forward)
   left.normalize()
-  left.multiplyScalar(MOVE_AMOUNT)
+  left.multiplyScalar(CameraMovementParameters.MOVE_AMOUNT)
   return left
 }
 

--- a/app/src/js/action/point_cloud.ts
+++ b/app/src/js/action/point_cloud.ts
@@ -6,8 +6,8 @@ import { Vector3D } from '../math/vector3d'
 import * as types from './types'
 
 export const MOUSE_CORRECTION_FACTOR = 60.0
-export const MOVE_AMOUNT = 0.3
-export const ZOOM_SPEED = 1.1
+export const MOVE_AMOUNT = 0.15
+export const ZOOM_SPEED = 1.05
 export enum CameraLockState {
   UNLOCKED = 0,
   X_LOCKED = 1,

--- a/app/src/js/components/viewer3d.tsx
+++ b/app/src/js/components/viewer3d.tsx
@@ -371,10 +371,14 @@ class Viewer3D extends DrawableViewer<Props> {
 
   /** Override key handler */
   protected onKeyDown (e: KeyboardEvent): void {
-    const viewerConfig = this._viewerConfig as PointCloudViewerConfigType
-    if (lockedToSelection(viewerConfig)) {
+    if (Session.activeViewerId !== this.props.id) {
       return
     }
+
+    const viewerConfig = this._viewerConfig as PointCloudViewerConfigType
+    // if (lockedToSelection(viewerConfig)) {
+    //   return
+    // }
     switch (e.key) {
       case types.Key.PERIOD:
         Session.dispatch(moveUp(this._viewerId, viewerConfig))

--- a/app/src/js/components/viewer3d.tsx
+++ b/app/src/js/components/viewer3d.tsx
@@ -6,7 +6,7 @@ import { withStyles } from '@material-ui/styles'
 import React from 'react'
 import * as THREE from 'three'
 import { changeViewerConfig, toggleSynchronization } from '../action/common'
-import { alignToAxis, CameraLockState, lockedToSelection, MOUSE_CORRECTION_FACTOR, MOVE_AMOUNT, moveCameraAndTarget, toggleSelectionLock, updateLockStatus, ZOOM_SPEED } from '../action/point_cloud'
+import { alignToAxis, CameraLockState, CameraMovementParameters, lockedToSelection, moveCameraAndTarget, toggleSelectionLock, updateLockStatus } from '../action/point_cloud'
 import Session from '../common/session'
 import * as types from '../common/types'
 import { PointCloudViewerConfigType } from '../functional/types'
@@ -55,8 +55,8 @@ function calculateForward (
   let forwardX = viewerConfig.target.x - viewerConfig.position.x
   let forwardY = viewerConfig.target.y - viewerConfig.position.y
   const forwardDist = Math.sqrt(forwardX * forwardX + forwardY * forwardY)
-  forwardX *= MOVE_AMOUNT / forwardDist
-  forwardY *= MOVE_AMOUNT / forwardDist
+  forwardX *= CameraMovementParameters.MOVE_AMOUNT / forwardDist
+  forwardY *= CameraMovementParameters.MOVE_AMOUNT / forwardDist
   return new THREE.Vector3(forwardX, forwardY, 0)
 }
 
@@ -80,7 +80,7 @@ function calculateLeft (
   const left = new THREE.Vector3()
   left.crossVectors(vertical, forward)
   left.normalize()
-  left.multiplyScalar(MOVE_AMOUNT)
+  left.multiplyScalar(CameraMovementParameters.MOVE_AMOUNT)
   return left
 }
 
@@ -591,7 +591,9 @@ class Viewer3D extends DrawableViewer<Props> {
     this._camera.getWorldDirection(axis)
 
     const quaternion = new THREE.Quaternion()
-    quaternion.setFromAxisAngle(axis, amount / MOUSE_CORRECTION_FACTOR)
+    quaternion.setFromAxisAngle(
+      axis, amount / CameraMovementParameters.MOUSE_CORRECTION_FACTOR
+    )
 
     this._camera.applyQuaternion(quaternion)
 
@@ -633,8 +635,8 @@ class Viewer3D extends DrawableViewer<Props> {
     spherical.setFromVector3(offset)
 
     // Apply rotations
-    spherical.theta += dx / MOUSE_CORRECTION_FACTOR
-    spherical.phi += dy / MOUSE_CORRECTION_FACTOR
+    spherical.theta += dx / CameraMovementParameters.MOUSE_CORRECTION_FACTOR
+    spherical.phi += dy / CameraMovementParameters.MOUSE_CORRECTION_FACTOR
 
     spherical.phi = Math.max(0, Math.min(Math.PI, spherical.phi))
 
@@ -655,8 +657,8 @@ class Viewer3D extends DrawableViewer<Props> {
   /** Drag camera, returns translation */
   private dragCamera (dx: number, dy: number): THREE.Vector3 {
     const dragVector = new THREE.Vector3(
-      -dx / MOUSE_CORRECTION_FACTOR * 2,
-      dy / MOUSE_CORRECTION_FACTOR * 2,
+      -dx / CameraMovementParameters.MOUSE_CORRECTION_FACTOR * 2,
+      dy / CameraMovementParameters.MOUSE_CORRECTION_FACTOR * 2,
       0
     )
     dragVector.applyQuaternion(this._camera.quaternion)
@@ -680,9 +682,9 @@ class Viewer3D extends DrawableViewer<Props> {
         // Decrease distance from origin by amount specified
       let newRadius = spherical.radius
       if (dY > 0) {
-        newRadius *= ZOOM_SPEED
+        newRadius *= CameraMovementParameters.ZOOM_SPEED
       } else {
-        newRadius /= ZOOM_SPEED
+        newRadius /= CameraMovementParameters.ZOOM_SPEED
       }
         // Limit zoom to not be too close
       if (newRadius > 0.1 && newRadius < 500) {
@@ -701,8 +703,8 @@ class Viewer3D extends DrawableViewer<Props> {
   /** Move camera up */
   private moveUp (): void {
     if (this._viewerConfig) {
-      this._camera.position.z += MOVE_AMOUNT
-      this._target.z += MOVE_AMOUNT
+      this._camera.position.z += CameraMovementParameters.MOVE_AMOUNT
+      this._target.z += CameraMovementParameters.MOVE_AMOUNT
       Session.label3dList.onDrawableUpdate()
     }
   }
@@ -710,8 +712,8 @@ class Viewer3D extends DrawableViewer<Props> {
   /** Move camera down */
   private moveDown (): void {
     if (this._viewerConfig) {
-      this._camera.position.z -= MOVE_AMOUNT
-      this._target.z -= MOVE_AMOUNT
+      this._camera.position.z -= CameraMovementParameters.MOVE_AMOUNT
+      this._target.z -= CameraMovementParameters.MOVE_AMOUNT
       Session.label3dList.onDrawableUpdate()
     }
   }


### PR DESCRIPTION
Currently, the camera movement from key presses and zooms is committed to state each time the UI handler fires, but this causes laggy behavior as the redux state must update very frequently. This PR changes the behavior to only dispatch actions to the store at the end of a scroll or when a user stops pressing a key.