### PR TITLE
Fix bug where project name is null

### DIFF
--- a/app/src/js/server/path.ts
+++ b/app/src/js/server/path.ts
@@ -106,6 +106,13 @@ export function getRedisBaseKey (metadataKey: string) {
 }
 
 /**
+ * Check redis key is a reminder key
+ */
+export function checkRedisReminderKey (key: string): boolean {
+  return key.split(':')[1] === 'reminder'
+}
+
+/**
  * Gets the redis key used by bots for the task
  */
 export function getRedisBotKey (botData: BotData) {

--- a/app/src/js/server/redis_store.ts
+++ b/app/src/js/server/redis_store.ts
@@ -36,6 +36,13 @@ export class RedisStore {
     // subscribe to reminder expirations for saving
     this.client.subscribe('__keyevent@0__:expired')
     this.client.on('message', async (_channel: string, reminderKey: string) => {
+      /**
+       * Check that the key is from a reminder expiring
+       * Not from a normal key or meta key expiring
+       */
+      if (!path.checkRedisReminderKey(reminderKey)) {
+        return
+      }
       const baseKey = path.getRedisBaseKey(reminderKey)
       const metaKey = path.getRedisMetaKey(baseKey)
       const metadata: StateMetadata = JSON.parse(await this.get(metaKey))

--- a/app/src/test/server/redis_store.test.ts
+++ b/app/src/test/server/redis_store.test.ts
@@ -54,7 +54,7 @@ describe('Test redis cache', () => {
     }
   })
 
-  test.only('Writes back on timeout', async () => {
+  test('Writes back on timeout', async () => {
     const timeoutConfig = _.clone(config)
     timeoutConfig.timeForWrite = 0.2
     timeoutConfig.redisTimeout = 0.4

--- a/app/src/test/server/redis_store.test.ts
+++ b/app/src/test/server/redis_store.test.ts
@@ -54,9 +54,10 @@ describe('Test redis cache', () => {
     }
   })
 
-  test('Writes back on timeout', async () => {
+  test.only('Writes back on timeout', async () => {
     const timeoutConfig = _.clone(config)
     timeoutConfig.timeForWrite = 0.2
+    timeoutConfig.redisTimeout = 0.4
     const store = new RedisStore(timeoutConfig, storage, client)
 
     const key = 'testKey1'


### PR DESCRIPTION
Fixed bug where project name is null. It occurred because we didn't filter out non-reminder keys from the Redis expiration listener. It also explains why it took so long, since normal keys only expire after 1 hour by default. 
Also modified the Redis tests so they fail without this fix.