### PR TITLE
updateState doesn't interrupt ongoing drawing

### DIFF
--- a/app/src/js/drawable/2d/label2d_list.ts
+++ b/app/src/js/drawable/2d/label2d_list.ts
@@ -151,6 +151,9 @@ export class Label2DList {
    * update labels from the state
    */
   public updateState (state: State): void {
+    if (this._updatedLabels.size > 0) {
+      return
+    }
     this._state = state
     this._labelTemplates = state.task.config.label2DTemplates
     const self = this
@@ -194,8 +197,10 @@ export class Label2DList {
   }
 
   /** Get uncommitted labels */
-  public get updatedLabels (): Readonly<Set<Readonly<Label2D>>> {
-    return this._updatedLabels
+  public popUpdatedLabels (): Label2D[] {
+    const labels = [...this._updatedLabels.values()]
+    this._updatedLabels.clear()
+    return labels
   }
 
   /** Push updated label to array */

--- a/app/src/test/drawable/label2d_handler.test.ts
+++ b/app/src/test/drawable/label2d_handler.test.ts
@@ -26,7 +26,7 @@ function initializeTestingObjects (): [Label2DHandler, number] {
   Session.dispatch(action.addViewerConfig(1, makeImageViewerConfig(0)))
   const viewerId = 1
 
-  const label2dHandler = new Label2DHandler()
+  const label2dHandler = new Label2DHandler(Session.label2dList)
   Session.subscribe(() => {
     const state = Session.getState()
     Session.label2dList.updateState(state)

--- a/app/src/test/project/box2d.disabledtest.tsx
+++ b/app/src/test/project/box2d.disabledtest.tsx
@@ -137,7 +137,7 @@ describe('full 2d bounding box integration test', () => {
     let state = Session.getState()
     const itemIndex = state.user.select.item
     const label2dList = new Label2DList()
-    const label2dHandler = new Label2DHandler()
+    const label2dHandler = new Label2DHandler(Session.label2dList)
     Session.subscribe(() => {
       const newState = Session.getState()
       Session.label2dList.updateState(newState)


### PR DESCRIPTION
The background state change may interrupt the user drawing action. This PR prevent this from happening by avoiding `updateState` if there are updated labels in `label2DList`. However, How handler, label list and label interact still require scrutinization. 