### PR TITLE
Fix Numeric Item Selector

### DIFF
--- a/app/src/js/styles/label.tsx
+++ b/app/src/js/styles/label.tsx
@@ -176,7 +176,6 @@ export const playerControlStyles = () => createStyles({
   input: {
     background: '#000000',
     color: 'green',
-    direction: 'rtl',
     width: '50px',
     fontWeight: 500,
     left: '-1px',


### PR DESCRIPTION
The current version behaves very strangely when you try to edit the number. The cursor is in the wrong position, etc. This happens because it is in right-to-left mode (meant for languages that read right to left). Removing this mode makes it look a bit worse in terms of alignment, but it behaves much better:
<img width="339" alt="Screen Shot 2020-06-17 at 3 48 21 PM" src="https://user-images.githubusercontent.com/16771430/84958439-39496500-b0b2-11ea-8f4c-0421c1a50272.png">
