### PR TITLE
Make the box2d testing procedure consistent and simplified

### DIFF
--- a/app/src/js/action/common.ts
+++ b/app/src/js/action/common.ts
@@ -1,5 +1,5 @@
 import { getStateGetter } from '../common/session'
-import { getStateFunc } from '../common/simple_store'
+import { GetStateFunc } from '../common/simple_store'
 import { ThunkCreatorType } from '../common/types'
 import { uid } from '../common/uid'
 import * as selector from '../functional/selector'
@@ -15,7 +15,7 @@ let getState = getStateGetter()
  * Set the state getter for actions
  * @param getter
  */
-export function setActionStateGetter (getter: getStateFunc) {
+export function setActionStateGetter (getter: GetStateFunc) {
   getState = getter
 }
 

--- a/app/src/js/common/session.ts
+++ b/app/src/js/common/session.ts
@@ -118,4 +118,11 @@ export function dispatch (action: types.ActionType | ThunkActionType): void {
   return session.dispatch(action)
 }
 
+/**
+ * Get the simple store object
+ */
+export function getStore (): SimpleStore {
+  return session.getSimpleStore()
+}
+
 export default session

--- a/app/src/js/common/session.ts
+++ b/app/src/js/common/session.ts
@@ -6,7 +6,7 @@ import { Label2DList } from '../drawable/2d/label2d_list'
 import { Label3DList } from '../drawable/3d/label3d_list'
 import { State } from '../functional/types'
 import { configureStore } from './configure_store'
-import { getStateFunc, SimpleStore } from './simple_store'
+import { GetStateFunc, SimpleStore } from './simple_store'
 import { Track } from './track/track'
 import { FullStore, ThunkActionType } from './types'
 
@@ -100,8 +100,22 @@ const session = new Session()
 /**
  * extract state getter from the session
  */
-export function getStateGetter (): getStateFunc {
+export function getStateGetter (): GetStateFunc {
   return session.getSimpleStore().getter()
+}
+
+/**
+ * Get state from the global session instance
+ */
+export function getState (): State {
+  return session.getState()
+}
+
+/**
+ * Dispatch the action to the global session instance
+ */
+export function dispatch (action: types.ActionType | ThunkActionType): void {
+  return session.dispatch(action)
 }
 
 export default session

--- a/app/src/js/common/session_setup.tsx
+++ b/app/src/js/common/session_setup.tsx
@@ -13,7 +13,7 @@ import { DeepPartialState, PointCloudViewerConfigType, SplitType, State } from '
 import { myTheme } from '../styles/theme'
 import { PLYLoader } from '../thirdparty/PLYLoader'
 import Session from './session'
-import { dispatchFunc, getStateFunc } from './simple_store'
+import { DispatchFunc, GetStateFunc } from './simple_store'
 import { Track } from './track/track'
 import { DataType, FullStore, ItemTypeName, ViewerConfigTypeName } from './types'
 
@@ -61,7 +61,7 @@ function renderDom (
 /**
  * Load labeling data initialization function
  */
-function loadData (getState: getStateFunc, dispatch: dispatchFunc): void {
+function loadData (getState: GetStateFunc, dispatch: DispatchFunc): void {
   loadImages(getState, dispatch)
   loadPointClouds(getState, dispatch)
 }
@@ -92,7 +92,7 @@ export function updateTracks (state: State): void {
  * Load all the images in the state
  */
 function loadImages (
-  getState: getStateFunc, dispatch: dispatchFunc,
+  getState: GetStateFunc, dispatch: DispatchFunc,
   maxAttempts: number = 3): void {
   const state = getState()
   const items = state.task.items
@@ -132,7 +132,7 @@ function loadImages (
  * Load all point clouds in state
  */
 function loadPointClouds (
-  getState: getStateFunc, dispatch: dispatchFunc,
+  getState: GetStateFunc, dispatch: DispatchFunc,
   maxAttempts: number = 3): void {
   const loader = new PLYLoader()
 
@@ -184,7 +184,7 @@ function loadPointClouds (
  * Create default viewer configs if none exist
  */
 function initViewerConfigs (
-  getState: getStateFunc, dispatch: dispatchFunc): void {
+  getState: GetStateFunc, dispatch: DispatchFunc): void {
   let state = getState()
   if (Object.keys(state.user.viewerConfigs).length === 0) {
     const sensorIds = Object.keys(state.task.sensors).map(

--- a/app/src/js/common/simple_store.ts
+++ b/app/src/js/common/simple_store.ts
@@ -1,19 +1,19 @@
 import { ActionType } from '../action/types'
 import { State } from '../functional/types'
 
-export type getStateFunc = () => State
-export type dispatchFunc = (actoin: ActionType) => void
+export type GetStateFunc = () => State
+export type DispatchFunc = (actoin: ActionType) => void
 
 /**
  * Simple store wrapper class
  */
 export class SimpleStore {
   /** get state function */
-  public getState: getStateFunc
+  public getState: GetStateFunc
   /** dispatch action function */
-  public dispatch: dispatchFunc
+  public dispatch: DispatchFunc
 
-  constructor (getState: getStateFunc, dispatch: dispatchFunc) {
+  constructor (getState: GetStateFunc, dispatch: DispatchFunc) {
     this.getState = getState
     this.dispatch = dispatch
   }
@@ -21,14 +21,14 @@ export class SimpleStore {
   /**
    * Get the standalone state accessor function
    */
-  public getter (): getStateFunc {
+  public getter (): GetStateFunc {
     return this.getState.bind(this)
   }
 
   /**
    * Get the standalone state dispatch function
    */
-  public dispatcher (): dispatchFunc {
+  public dispatcher (): DispatchFunc {
     return this.dispatch.bind(this)
   }
 }

--- a/app/src/js/functional/states.ts
+++ b/app/src/js/functional/states.ts
@@ -11,6 +11,7 @@ import {
   Image3DViewerConfigType,
   ImageViewerConfigType,
   IntrinsicsType,
+  INVALID_ID,
   ItemStatus,
   ItemType,
   LabelType,
@@ -579,14 +580,14 @@ export function makeState (params: Partial<State> = {}): State {
  * @param {IdType} id
  */
 export function isValidId (id: IdType): bool {
-  return id !== '' && id !== '-1'
+  return id !== INVALID_ID && id !== '-1'
 }
 
 /**
  * Make default ID
  */
 export function makeDefaultId (): IdType {
-  return ''
+  return INVALID_ID
 }
 
 /**

--- a/app/src/js/functional/types.ts
+++ b/app/src/js/functional/types.ts
@@ -1,6 +1,7 @@
 import { AttributeToolType } from '../common/types'
 
 export type IdType = string
+export const INVALID_ID: IdType = ''
 
 // Have to define those map because
 // we can't use alias of string as an index signature parameter type

--- a/app/src/test/components/box2d.test.tsx
+++ b/app/src/test/components/box2d.test.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import * as React from 'react'
 import * as action from '../../js/action/common'
-import Session from '../../js/common/session'
+import Session, { dispatch, getState } from '../../js/common/session'
 import { Label2dCanvas } from '../../js/components/label2d_canvas'
 import { testJson } from '../test_states/test_image_objects'
 import { checkBox2D } from '../util/shape'
@@ -9,9 +9,6 @@ import { drag, drawBox2D, setUpLabel2dCanvas } from './label2d_canvas_util'
 import { setupTestStore } from './util'
 
 const canvasRef: React.RefObject<Label2dCanvas> = React.createRef()
-
-const getState = Session.getState.bind(Session)
-const dispatch = Session.dispatch.bind(Session)
 
 beforeEach(() => {
   expect(canvasRef.current).not.toBeNull()

--- a/app/src/test/components/box2d.test.tsx
+++ b/app/src/test/components/box2d.test.tsx
@@ -3,9 +3,8 @@ import * as React from 'react'
 import * as action from '../../js/action/common'
 import Session from '../../js/common/session'
 import { Label2dCanvas } from '../../js/components/label2d_canvas'
-import { getShape } from '../../js/functional/state_util'
-import { RectType } from '../../js/functional/types'
 import { testJson } from '../test_states/test_image_objects'
+import { checkBox2D } from '../util/shape'
 import { drag, drawBox2D, setUpLabel2dCanvas } from './label2d_canvas_util'
 import { setupTestStore } from './util'
 
@@ -42,65 +41,38 @@ test('Draw 2d boxes to label2d list', () => {
   labelIds.push(drawBox2D(label2d, getState, 1, 1, 50, 50))
   let state = getState()
   expect(_.size(state.task.items[0].labels)).toEqual(1)
-  let rect = getShape(state, 0, labelIds[0], 0) as RectType
-  expect(rect.x1).toEqual(1)
-  expect(rect.y1).toEqual(1)
-  expect(rect.x2).toEqual(50)
-  expect(rect.y2).toEqual(50)
+  checkBox2D(labelIds[0], { x1: 1, y1: 1, x2: 50, y2: 50 })
 
   // Second box
   labelIds.push(drawBox2D(label2d, getState, 25, 20, 70, 85))
 
   state = getState()
   expect(_.size(state.task.items[0].labels)).toEqual(2)
-  rect = getShape(state, 0, labelIds[1], 0) as RectType
-  expect(rect.x1).toEqual(25)
-  expect(rect.y1).toEqual(20)
-  expect(rect.x2).toEqual(70)
-  expect(rect.y2).toEqual(85)
+  checkBox2D(labelIds[1], { x1: 25, y1: 20, x2: 70, y2: 85 })
 
   // Third box
   labelIds.push(drawBox2D(label2d, getState, 15, 10, 60, 70))
   state = getState()
   expect(_.size(state.task.items[0].labels)).toEqual(3)
-  rect = getShape(state, 0, labelIds[2], 0) as RectType
-  expect(rect.x1).toEqual(15)
-  expect(rect.y1).toEqual(10)
-  expect(rect.x2).toEqual(60)
-  expect(rect.y2).toEqual(70)
+  checkBox2D(labelIds[2], { x1: 15, y1: 10, x2: 60, y2: 70 })
 
   // Resize the second box
   drag(label2d, 25, 20, 30, 34)
   state = getState()
   expect(_.size(state.task.items[0].labels)).toEqual(3)
-  rect = getShape(state, 0, labelIds[1], 0) as RectType
-  expect(rect.x1).toEqual(30)
-  expect(rect.y1).toEqual(34)
+  checkBox2D(labelIds[1], { x1: 30, y1: 34 })
 
   // Move the resized second box
   drag(label2d, 30, 50, 40, 60)
-  state = getState()
-  rect = getShape(state, 0, labelIds[1], 0) as RectType
-  expect(rect.x1).toEqual(40)
-  expect(rect.y1).toEqual(44)
+  checkBox2D(labelIds[1], { x1: 40, y1: 44 })
 
   // Flip top left and bottom right corner
   drag(label2d, 40, 44, 100, 100)
-  state = getState()
-  rect = getShape(state, 0, labelIds[1], 0) as RectType
-  expect(rect.x1).toEqual(80)
-  expect(rect.y1).toEqual(95)
-  expect(rect.x2).toEqual(100)
-  expect(rect.y2).toEqual(100)
+  checkBox2D(labelIds[1], { x1: 80, y1: 95, x2: 100, y2: 100 })
 
   // Move the third box
   drag(label2d, 30, 10, 40, 15)
-  state = getState()
-  rect = getShape(state, 0, labelIds[2], 0) as RectType
-  expect(rect.x1).toEqual(25)
-  expect(rect.y1).toEqual(15)
-  expect(rect.x2).toEqual(70)
-  expect(rect.y2).toEqual(75)
+  checkBox2D(labelIds[2], { x1: 25, y1: 15, x2: 70, y2: 75 })
 })
 
 // Test('Switch box order', () => {

--- a/app/src/test/components/label2d_canvas.test.tsx
+++ b/app/src/test/components/label2d_canvas.test.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import * as React from 'react'
 import * as action from '../../js/action/common'
-import Session from '../../js/common/session'
+import Session, { dispatch, getState } from '../../js/common/session'
 import { Label2dCanvas } from '../../js/components/label2d_canvas'
 import { getShape } from '../../js/functional/state_util'
 import { PolygonType } from '../../js/functional/types'
@@ -11,8 +11,6 @@ import { LabelCollector } from '../util/label_collector'
 import { drawPolygon, keyDown, keyUp, mouseDown, mouseMove, mouseMoveClick, mouseUp, setUpLabel2dCanvas } from './label2d_canvas_util'
 
 const canvasRef: React.RefObject<Label2dCanvas> = React.createRef()
-const getState = Session.getState.bind(Session)
-const dispatch = Session.dispatch.bind(Session)
 
 beforeEach(() => {
   expect(canvasRef.current).not.toBeNull()

--- a/app/src/test/components/label2d_canvas_util.tsx
+++ b/app/src/test/components/label2d_canvas_util.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import * as React from 'react'
 import * as action from '../../js/action/common'
 import { ActionType } from '../../js/action/types'
-import { getStateFunc, SimpleStore } from '../../js/common/simple_store'
+import { GetStateFunc, SimpleStore } from '../../js/common/simple_store'
 import { Label2dCanvas } from '../../js/components/label2d_canvas'
 import { makeImageViewerConfig } from '../../js/functional/states'
 import { IdType } from '../../js/functional/types'
@@ -148,7 +148,7 @@ export function drag (
  * @returns The id of the new label drawn on thecanvas
  */
 export function drawBox2D (
-  label2d: Label2dCanvas, getState: getStateFunc | null,
+  label2d: Label2dCanvas, getState: GetStateFunc | null,
   x1: number, y1: number, x2: number, y2: number): IdType {
   if (getState !== null) {
     const boxIds = new LabelCollector(getState)

--- a/app/src/test/components/toolbar.test.tsx
+++ b/app/src/test/components/toolbar.test.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import { create } from 'react-test-renderer'
 import * as action from '../../js/action/common'
 import { selectLabel } from '../../js/action/select'
-import Session from '../../js/common/session'
+import Session, { dispatch, getState } from '../../js/common/session'
 import { ToolBar } from '../../js/components/toolbar'
 import { Category } from '../../js/components/toolbar_category'
 import { ListButton } from '../../js/components/toolbar_list_button'
@@ -18,9 +18,6 @@ import { setupTestStore } from './util'
 let handleToggleWasCalled: boolean = false
 const testValues = ['NA', 'A', 'B', 'C']
 const selected: {[key: string]: string} = {}
-
-const getState = Session.getState.bind(Session)
-const dispatch = Session.dispatch.bind(Session)
 
 /**
  * dummy attribute toggle function to test if the correct toggle action was

--- a/app/src/test/components/track.test.tsx
+++ b/app/src/test/components/track.test.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import React from 'react'
 import * as action from '../../js/action/common'
 import { selectLabel } from '../../js/action/select'
-import Session from '../../js/common/session'
+import Session, { dispatch, getState, getStore } from '../../js/common/session'
 import { updateTracks } from '../../js/common/session_setup'
 import { Label2dCanvas } from '../../js/components/label2d_canvas'
 import { ToolBar } from '../../js/components/toolbar'
@@ -15,10 +15,6 @@ import { drag, drawBox2DTracks, mouseMoveClick, setUpLabel2dCanvas } from './lab
 import { setupTestStore } from './util'
 
 const canvasRef: React.RefObject<Label2dCanvas> = React.createRef()
-
-const store = Session.getSimpleStore()
-const getState = store.getter()
-const dispatch = store.dispatcher()
 
 beforeEach(() => {
   expect(canvasRef.current).not.toBeNull()
@@ -73,7 +69,7 @@ describe('basic track ops', () => {
     ]
 
     // Test adding tracks
-    const trackIds = drawBox2DTracks(label2d, store, itemIndices, boxes)
+    const trackIds = drawBox2DTracks(label2d, getStore(), itemIndices, boxes)
     let state = getState()
     expect(_.size(state.task.tracks)).toEqual(4)
     itemIndices.forEach((itemIndex, i) => {
@@ -165,7 +161,7 @@ describe('basic track ops', () => {
       [500, 500, 80, 100]
     ]
 
-    const trackIds = drawBox2DTracks(label2d, store, itemIndices, boxes)
+    const trackIds = drawBox2DTracks(label2d, getStore(), itemIndices, boxes)
 
     // Terminate the track by button
     let state = getState()
@@ -232,7 +228,7 @@ describe('basic track ops', () => {
       [1, 1, 50, 50]
     ]
 
-    const trackIds = drawBox2DTracks(label2d, store, itemIndices, boxes)
+    const trackIds = drawBox2DTracks(label2d, getStore(), itemIndices, boxes)
 
     // Changing category
     dispatch(action.goToItem(2))
@@ -272,7 +268,7 @@ describe('basic track ops', () => {
       [100, 110, 200, 300]
     ]
 
-    const trackIds = drawBox2DTracks(label2d, store, itemIndices, boxes)
+    const trackIds = drawBox2DTracks(label2d, getStore(), itemIndices, boxes)
 
     // Changing shape
     dispatch(action.goToItem(4))

--- a/app/src/test/components/track.test.tsx
+++ b/app/src/test/components/track.test.tsx
@@ -7,10 +7,10 @@ import Session from '../../js/common/session'
 import { updateTracks } from '../../js/common/session_setup'
 import { Label2dCanvas } from '../../js/components/label2d_canvas'
 import { ToolBar } from '../../js/components/toolbar'
-import { getShape } from '../../js/functional/state_util'
-import { RectType, State } from '../../js/functional/types'
+import { State } from '../../js/functional/types'
 // Import { TrackCollector } from '../server/util/track_collector'
 import { emptyTrackingTask } from '../test_states/test_track_objects'
+import { checkBox2D } from '../util/shape'
 import { drag, drawBox2DTracks, mouseMoveClick, setUpLabel2dCanvas } from './label2d_canvas_util'
 import { setupTestStore } from './util'
 
@@ -280,41 +280,29 @@ describe('basic track ops', () => {
     let state = getState()
     // Shapes starting from item 4 should change
     for (let i = 4; i < 8; ++i) {
-      const labelIdInk = state.task.tracks[trackIds[0]].labels[i]
-      const rect = getShape(state, i, labelIdInk, 0) as RectType
-      expect(rect.x1).toEqual(15)
-      expect(rect.y1).toEqual(25)
-      expect(rect.x2).toEqual(50)
-      expect(rect.y2).toEqual(60)
+      checkBox2D(
+        state.task.tracks[trackIds[0]].labels[i],
+        { x1: 15, y1: 25, x2: 50, y2: 60 }, i)
     }
     // Shapes before item 4 should not change
     for (let i = 0; i < 4; ++i) {
-      const labelIdInk = state.task.tracks[trackIds[0]].labels[i]
-      const rect = getShape(state, i, labelIdInk, 0) as RectType
-      expect(rect.x1).toEqual(10)
-      expect(rect.y1).toEqual(20)
-      expect(rect.x2).toEqual(50)
-      expect(rect.y2).toEqual(60)
+      checkBox2D(
+        state.task.tracks[trackIds[0]].labels[i],
+        { x1: 10, y1: 20, x2: 50, y2: 60 }, i)
     }
     dispatch(action.goToItem(6))
     drag(label2d, 50, 60, 55, 65)
     state = getState()
     // Shapes should change only between item 6 to 8
     for (let i = 6; i < 8; ++i) {
-      const labelIdInk = state.task.tracks[trackIds[0]].labels[i]
-      const rect = getShape(state, i, labelIdInk, 0) as RectType
-      expect(rect.x1).toEqual(15)
-      expect(rect.y1).toEqual(25)
-      expect(rect.x2).toEqual(55)
-      expect(rect.y2).toEqual(65)
+      checkBox2D(
+        state.task.tracks[trackIds[0]].labels[i],
+        { x1: 15, y1: 25, x2: 55, y2: 65 }, i)
     }
     for (let i = 4; i < 6; ++i) {
-      const labelIdInk = state.task.tracks[trackIds[0]].labels[i]
-      const rect = getShape(state, i, labelIdInk, 0) as RectType
-      expect(rect.x1).toEqual(15)
-      expect(rect.y1).toEqual(25)
-      expect(rect.x2).toEqual(50)
-      expect(rect.y2).toEqual(60)
+      checkBox2D(
+        state.task.tracks[trackIds[0]].labels[i],
+        { x1: 15, y1: 25, x2: 50, y2: 60 }, i)
     }
     // Changing location
     dispatch(action.goToItem(5))
@@ -322,21 +310,15 @@ describe('basic track ops', () => {
     state = getState()
     // Locations starting from item 5 should change
     for (let i = 5; i < 8; ++i) {
-      const labelIdInk = state.task.tracks[trackIds[1]].labels[i]
-      const rect = getShape(state, i, labelIdInk, 0) as RectType
-      expect(rect.x1).toEqual(200)
-      expect(rect.y1).toEqual(210)
-      expect(rect.x2).toEqual(300)
-      expect(rect.y2).toEqual(400)
+      checkBox2D(
+        state.task.tracks[trackIds[1]].labels[i],
+        { x1: 200, y1: 210, x2: 300, y2: 400 }, i)
     }
     // Locations before item 5 should not change
     for (let i = 2; i < 5; ++i) {
-      const labelIdInk = state.task.tracks[trackIds[1]].labels[i]
-      const rect = getShape(state, i, labelIdInk, 0) as RectType
-      expect(rect.x1).toEqual(100)
-      expect(rect.y1).toEqual(110)
-      expect(rect.x2).toEqual(200)
-      expect(rect.y2).toEqual(300)
+      checkBox2D(
+        state.task.tracks[trackIds[1]].labels[i],
+        { x1: 100, y1: 110, x2: 200, y2: 300 }, i)
     }
 
   })

--- a/app/src/test/drawable/box2d_label.test.ts
+++ b/app/src/test/drawable/box2d_label.test.ts
@@ -1,19 +1,17 @@
 import fs from 'fs-extra'
 import _ from 'lodash'
 import * as action from '../../js/action/common'
-import Session from '../../js/common/session'
+import Session, { dispatch, getState } from '../../js/common/session'
 import { Label2DList, makeDrawableLabel2D } from '../../js/drawable/2d/label2d_list'
 import { commit2DLabels } from '../../js/drawable/states'
 import { makeImageViewerConfig } from '../../js/functional/states'
-import { RectType, State } from '../../js/functional/types'
+import { RectType } from '../../js/functional/types'
 import { Size2D } from '../../js/math/size2d'
 import { Vector2D } from '../../js/math/vector2d'
 import { setupTestStore } from '../components/util'
 
-const data = JSON.parse(fs.readFileSync('./app/src/test/test_states/sample_state.json', 'utf8'))
-const getState = Session.getState.bind(Session)
-const dispatch = Session.dispatch.bind(Session)
-let tracking: boolean
+const data = JSON.parse(fs.readFileSync(
+  './app/src/test/test_states/sample_state.json', 'utf8'))
 
 beforeEach(() => {
   setupTestStore(data)
@@ -21,7 +19,6 @@ beforeEach(() => {
 
 beforeAll(() => {
   setupTestStore(data)
-  tracking = (data as State).task.config.tracking
 
   Session.images.length = 0
   Session.images.push({ [-1]: new Image(1000, 1000) })
@@ -48,7 +45,7 @@ test('Add new valid drawable', () => {
     label.onMouseMove(new Vector2D(20, 20), new Size2D(1000, 1000), 1, 2)
     label.onMouseUp(new Vector2D(20, 20))
 
-    commit2DLabels([label], tracking)
+    commit2DLabels([label], state.task.config.tracking)
 
     const currentState = Session.getState()
     expect(_.size(currentState.task.items[0].labels)).toEqual(4)
@@ -74,7 +71,7 @@ test('Add new invalid drawable', () => {
     label.onMouseMove(new Vector2D(12, 12), new Size2D(1000, 1000), 1, 2)
     label.onMouseUp(new Vector2D(12, 12))
 
-    commit2DLabels([label], tracking)
+    commit2DLabels([label], state.task.config.tracking)
 
     const currentState = Session.getState()
     expect(_.size(currentState.task.items[0].labels)).toEqual(3)
@@ -99,7 +96,7 @@ test('Update existing drawable', () => {
   label.onMouseMove(new Vector2D(700, 300), new Size2D(1000, 1000), 1, 2)
   label.onMouseUp(new Vector2D(700, 300))
 
-  commit2DLabels([label], tracking)
+  commit2DLabels([label], state.task.config.tracking)
 
   const currentState = Session.getState()
   const newLabel = currentState.task.items[0].labels['1']
@@ -126,7 +123,7 @@ test('Update existing drawable to invalid', () => {
   label.onMouseMove(new Vector2D(460, 280), new Size2D(1000, 1000), 1, 2)
   label.onMouseUp(new Vector2D(460, 280))
 
-  commit2DLabels([label], tracking)
+  commit2DLabels([label], state.task.config.tracking)
 
   const currentState = Session.getState()
   expect(currentState.task.items[0].labels['1']).toBeUndefined()

--- a/app/src/test/drawable/track_label.test.ts
+++ b/app/src/test/drawable/track_label.test.ts
@@ -1,26 +1,18 @@
 import _ from 'lodash'
 import * as action from '../../js/action/common'
-import Session from '../../js/common/session'
+import Session, { dispatch, getState } from '../../js/common/session'
 import { updateTracks } from '../../js/common/session_setup'
 import { Label2DList, makeDrawableLabel2D } from '../../js/drawable/2d/label2d_list'
 import { commit2DLabels } from '../../js/drawable/states'
 import { makeImageViewerConfig } from '../../js/functional/states'
-import { RectType, State } from '../../js/functional/types'
+import { RectType } from '../../js/functional/types'
 import { Size2D } from '../../js/math/size2d'
 import { Vector2D } from '../../js/math/vector2d'
 import { setupTestStore } from '../components/util'
 import { testJson } from '../test_states/test_track_objects'
 
-const store = Session.getSimpleStore()
-const getState = store.getter()
-const dispatch = store.dispatcher()
-// TODO: Remove tracking global variable. This should be done after
-// label list and label refactoring.
-let tracking: boolean
-
 beforeAll(() => {
   setupTestStore(testJson)
-  tracking = (testJson as State).task.config.tracking
 
   Session.images.length = 0
   for (let i = 0; i < getState().task.items.length; i++) {
@@ -49,7 +41,7 @@ test('Add new valid drawable track', () => {
     label.onMouseMove(new Vector2D(20, 20), new Size2D(1000, 1000), 1, 2)
     label.onMouseUp(new Vector2D(20, 20))
 
-    commit2DLabels([label], tracking)
+    commit2DLabels([label], state.task.config.tracking)
 
     const currentState = getState()
     expect(_.size(currentState.task.items[0].labels)).toEqual(4)
@@ -92,7 +84,7 @@ test('Add new invalid drawable track', () => {
     label.onMouseMove(new Vector2D(12, 12), new Size2D(1000, 1000), 1, 2)
     label.onMouseUp(new Vector2D(12, 12))
 
-    commit2DLabels([label], tracking)
+    commit2DLabels([label], state.task.config.tracking)
 
     const currentState = getState()
     expect(_.size(currentState.task.items[0].labels)).toEqual(3)
@@ -120,7 +112,7 @@ test('Update existing drawable of a track', () => {
   label.onMouseMove(new Vector2D(850, 350), new Size2D(1200, 1200), 1, 2)
   label.onMouseUp(new Vector2D(850, 350))
 
-  commit2DLabels([label], tracking)
+  commit2DLabels([label], state.task.config.tracking)
 
   const currentState = getState()
   const newLabel = currentState.task.items[1].labels['70']
@@ -163,7 +155,7 @@ test('Update existing drawable of a track to invalid, from page 1', () => {
   const trackId = label.trackId
   const oldTrackLabels = state.task.tracks[trackId].labels
 
-  commit2DLabels([label], tracking)
+  commit2DLabels([label], state.task.config.tracking)
 
   const currentState = getState()
   const newLabel = currentState.task.items[1].labels['70']
@@ -205,7 +197,7 @@ test('Update existing drawable of a track to invalid, from page 0', () => {
   const trackId = label.trackId
   const oldTrackLabels = state.task.tracks[trackId].labels
 
-  commit2DLabels([label], tracking)
+  commit2DLabels([label], state.task.config.tracking)
 
   const currentState = getState()
   const newLabel = currentState.task.items[0].labels['69']

--- a/app/src/test/drawable/track_label.test.ts
+++ b/app/src/test/drawable/track_label.test.ts
@@ -14,6 +14,8 @@ import { testJson } from '../test_states/test_track_objects'
 const store = Session.getSimpleStore()
 const getState = store.getter()
 const dispatch = store.dispatcher()
+// TODO: Remove tracking global variable. This should be done after
+// label list and label refactoring.
 let tracking: boolean
 
 beforeAll(() => {

--- a/app/src/test/server/util/track_collector.ts
+++ b/app/src/test/server/util/track_collector.ts
@@ -1,5 +1,5 @@
 import { IdType } from 'aws-sdk/clients/workdocs'
-import { getStateFunc } from '../../../js/common/simple_store'
+import { GetStateFunc } from '../../../js/common/simple_store'
 import { findNewTracksFromState } from './util'
 
 /**
@@ -8,9 +8,9 @@ import { findNewTracksFromState } from './util'
 export class TrackCollector extends Array<IdType> {
 
   /** access the state */
-  private _getState: getStateFunc
+  private _getState: GetStateFunc
 
-  constructor (getState: getStateFunc) {
+  constructor (getState: GetStateFunc) {
     super()
     this._getState = getState
   }

--- a/app/src/test/util/label_collector.ts
+++ b/app/src/test/util/label_collector.ts
@@ -1,4 +1,4 @@
-import { getStateFunc } from '../../js/common/simple_store'
+import { GetStateFunc } from '../../js/common/simple_store'
 import { IdType } from '../../js/functional/types'
 import { findNewLabelsFromState } from '../server/util/util'
 
@@ -8,9 +8,9 @@ import { findNewLabelsFromState } from '../server/util/util'
 export class LabelCollector extends Array<IdType> {
 
   /** access the state */
-  private _getState: getStateFunc
+  private _getState: GetStateFunc
 
-  constructor (getState: getStateFunc) {
+  constructor (getState: GetStateFunc) {
     super()
     this._getState = getState
   }

--- a/app/src/test/util/shape.ts
+++ b/app/src/test/util/shape.ts
@@ -1,0 +1,48 @@
+import { getState } from '../../js/common/session'
+import { GetStateFunc } from '../../js/common/simple_store'
+import { getShape } from '../../js/functional/state_util'
+import { IdType, PolygonType, SimpleRect } from '../../js/functional/types'
+
+/**
+ * Check that the box's coords are correct
+ * @param labelId: Id of the box
+ * @param coords: Coords of the box
+ * @param itemIndex: item index of the label. Use the current item by default
+ * @param getStateFunc: get the state. Use the session get state by default
+ */
+export function checkBox2D (
+  labelId: IdType, target: Partial<SimpleRect>,
+  itemIndex: number = -1,
+  getStateFunc: GetStateFunc = getState) {
+  const state = getStateFunc()
+  if (itemIndex < 0) {
+    itemIndex = state.user.select.item
+  }
+  const rect = getShape(state, itemIndex, labelId, 0)
+  expect(rect).toMatchObject(target)
+}
+
+/**
+ * Check that the polygon's vertices are correct
+ * @param labelId: Id of the polygon
+ * @param coords: List of vertices of the polygon
+ * @param itemIndex: item index of the label. Use the current item by default
+ * @param getStateFunc: get the state. Use the session get state by default
+ */
+export function checkPolygon (
+  labelId: IdType, coords: number[][],
+  itemIndex: number = -1,
+  getStateFunc: GetStateFunc = getState) {
+  const state = getStateFunc()
+  if (itemIndex < 0) {
+    itemIndex = state.user.select.item
+  }
+  const points = (getShape(state, 0, labelId, 0) as PolygonType).points
+  expect(points.length).toEqual(coords.length)
+  for (let pointIndex = 0; pointIndex < points.length; pointIndex++) {
+    expect(points[pointIndex]).toMatchObject(
+      { x: coords[pointIndex][0],
+        y: coords[pointIndex][1],
+        pointType: 'vertex' })
+  }
+}


### PR DESCRIPTION
- Same `CheckBox2D` between components and drawable
- Replace element-wise checking with object-level checking
- Remove the global variable 
- `2DBox` -> `Box2D` for consistency
- Polygon checking is not changed significantly due to forthcoming shape refactoring