### PR TITLE
Fix meta/control key capture issue during window switch

### DIFF
--- a/app/src/js/common/window.ts
+++ b/app/src/js/common/window.ts
@@ -1,0 +1,14 @@
+/**
+ * Add callback for the main window visibility change
+ */
+export function addVisibilityListener (callback: (visible: boolean) => void) {
+  window.addEventListener('blur', () => {
+    callback(false)
+  })
+  window.addEventListener('focus', () => {
+    callback(true)
+  })
+  window.addEventListener('visibilitychange', () => {
+    callback(!document.hidden)
+  })
+}

--- a/app/src/js/components/label2d_canvas.tsx
+++ b/app/src/js/components/label2d_canvas.tsx
@@ -163,18 +163,19 @@ export class Label2dCanvas extends DrawableCanvas<Props> {
         }
       }}
     />)
-    let labelCanvas = (<canvas
-      key='label2d-canvas'
-      className={classes.label2d_canvas}
-      ref={(canvas) => {
-        if (canvas) {
-          this.updateCanvas(canvas, false)
-        }
-      }}
-      onMouseDown={(e) => { this.onMouseDown(e) }}
-      onMouseUp={(e) => { this.onMouseUp(e) }}
-      onMouseMove={(e) => { this.onMouseMove(e) }}
-    />)
+    let labelCanvas = (
+        <canvas
+          key='label2d-canvas'
+          className={classes.label2d_canvas}
+          ref={(canvas) => {
+            if (canvas) {
+              this.updateCanvas(canvas, false)
+            }
+          }}
+          onMouseDown={(e) => { this.onMouseDown(e) }}
+          onMouseUp={(e) => { this.onMouseUp(e) }}
+          onMouseMove={(e) => { this.onMouseMove(e) }}
+        />)
     const ch = (<Crosshair
       key='crosshair-canvas'
       display={this.display}

--- a/app/src/js/components/util.ts
+++ b/app/src/js/components/util.ts
@@ -18,18 +18,3 @@ export function getSubmissionTime (submissions: SubmitData[]) {
   }
   return -1
 }
-
-/**
- * Add callback for the main window visibility change
- */
-export function addVisibilityListener (callback: (visible: boolean) => void) {
-  window.addEventListener('blur', () => {
-    callback(false)
-  })
-  window.addEventListener('focus', () => {
-    callback(true)
-  })
-  window.addEventListener('visibilitychange', () => {
-    callback(!document.hidden)
-  })
-}

--- a/app/src/js/components/util.ts
+++ b/app/src/js/components/util.ts
@@ -18,3 +18,18 @@ export function getSubmissionTime (submissions: SubmitData[]) {
   }
   return -1
 }
+
+/**
+ * Add callback for the main window visibility change
+ */
+export function addVisibilityListener (callback: (visible: boolean) => void) {
+  window.addEventListener('blur', () => {
+    callback(false)
+  })
+  window.addEventListener('focus', () => {
+    callback(true)
+  })
+  window.addEventListener('visibilitychange', () => {
+    callback(!document.hidden)
+  })
+}

--- a/app/src/js/drawable/2d/label2d_handler.ts
+++ b/app/src/js/drawable/2d/label2d_handler.ts
@@ -2,6 +2,7 @@ import { changeLabelsProps, linkLabels, mergeTracks, startLinkTrack, unlinkLabel
 import { selectLabels, unselectLabels } from '../../action/select'
 import Session from '../../common/session'
 import { Key } from '../../common/types'
+import { addVisibilityListener } from '../../components/util'
 import { getLinkedLabelIds } from '../../functional/common'
 import { tracksOverlapping } from '../../functional/track'
 import { IdType, State } from '../../functional/types'
@@ -36,6 +37,8 @@ export class Label2DHandler {
     this._selectedItemIndex = -1
     this._labelList = labelList
     this._tracking = tracking
+
+    addVisibilityListener(this.onVisibilityChange.bind(this))
   }
 
   /** get highlightedLabel for state inspection */
@@ -246,6 +249,15 @@ export class Label2DHandler {
     for (const selectedLabel of this._labelList.selectedLabels) {
       selectedLabel.onKeyUp(e.key)
     }
+  }
+
+  /**
+   * Handling function for canvas visibility change
+   * @param _isVisible
+   */
+  public onVisibilityChange (_isVisible: boolean): void {
+    delete this._keyDownMap[Key.META]
+    delete this._keyDownMap[Key.CONTROL]
   }
 
   /** returns whether selectedLabels is empty */

--- a/app/src/js/drawable/2d/label2d_handler.ts
+++ b/app/src/js/drawable/2d/label2d_handler.ts
@@ -2,7 +2,7 @@ import { changeLabelsProps, linkLabels, mergeTracks, startLinkTrack, unlinkLabel
 import { selectLabels, unselectLabels } from '../../action/select'
 import Session from '../../common/session'
 import { Key } from '../../common/types'
-import { addVisibilityListener } from '../../components/util'
+import { addVisibilityListener } from '../../common/window'
 import { getLinkedLabelIds } from '../../functional/common'
 import { tracksOverlapping } from '../../functional/track'
 import { IdType, State } from '../../functional/types'

--- a/package-lock.json
+++ b/package-lock.json
@@ -16683,6 +16683,15 @@
             "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
             "dev": true
         },
+        "react-page-visibility": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/react-page-visibility/-/react-page-visibility-6.2.0.tgz",
+            "integrity": "sha512-jCXAMx+8tioRoviWuaJqcAfu3DzQ3JBQBUn0KoneTQ0FQqMSpNWU4VbUuyVm9+i8+8T0beeDv1aV7VZq280vBA==",
+            "dev": true,
+            "requires": {
+                "prop-types": "^15.7.2"
+            }
+        },
         "react-redux": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-event-listener": "^0.6.6",
+        "react-page-visibility": "^6.2.0",
         "react-redux": "^7.2.0",
         "react-split-pane": "^0.1.91",
         "react-test-renderer": "^16.13.1",


### PR DESCRIPTION
CMD key can bring the interface into special labeling mode. But CMD+TAB can switch to another window and keep the current scalable canvas on the special mode. As shown in the gif below, when the user goes back to the scalabel window by mouse click, the label drawing can fail to finish unless CMD key is pressed again. This PR fixes this issue by adding a window visibility listener and using it in the handler.

![demo_4](https://user-images.githubusercontent.com/1063562/85627691-c6953800-b623-11ea-919c-a2da9b9f23e5.gif)
