### PR TITLE
Fix changing attributes

### DIFF
--- a/app/src/js/functional/states.ts
+++ b/app/src/js/functional/states.ts
@@ -59,7 +59,7 @@ export function makeLabel (params: Partial<LabelType> = {},
     track: INVALID_ID,
     order: 0,
     manual: true, // By default, manual is true
-    ...params
+    ..._.cloneDeep(params)
   }
   if (!keepId) {
     label.id = genLabelId()

--- a/app/src/test/functional/state.test.ts
+++ b/app/src/test/functional/state.test.ts
@@ -13,6 +13,7 @@ describe('Defaults get overwritten', () => {
     expect(itemExport.timestamp).toBe(timestamp)
     expect(itemExport.url).toBe('')
   })
+
   test('Label export creation',() => {
     const label = makeLabel()
     const category = 'category'
@@ -23,5 +24,22 @@ describe('Defaults get overwritten', () => {
     expect(labelExport.id).toBe(label.id)
     expect(labelExport.category).toBe(category)
     expect(labelExport.box2d).toBe(null)
+  })
+
+  test('Attributes are immutable', () => {
+    const attributes = {
+      0: [1],
+      1: [0]
+    }
+    const label = makeLabel({
+      attributes
+    })
+    expect(label.attributes[0]).toStrictEqual([1])
+    expect(label.attributes[1]).toStrictEqual([0])
+
+    // Mutating original attribute should not affect the label
+    attributes[0] = [0]
+    expect(label.attributes[0]).toStrictEqual([1])
+    expect(label.attributes[1]).toStrictEqual([0])
   })
 })


### PR DESCRIPTION
The bug is that attributes would change for unselected labels. 

The cause is that the selected labels are used to initialize labels, but are not copied. Thus changes in the selection propagate to previous labels.

The fix is to make a deep clone of the selected labels before using them to initialize a new label. 