### PR TITLE
Enable bounding box linear interpolation

### DIFF
--- a/app/src/js/common/track/policy/linear_interpolation/box2d_linear_interpolation.ts
+++ b/app/src/js/common/track/policy/linear_interpolation/box2d_linear_interpolation.ts
@@ -1,3 +1,4 @@
+import { makeRect } from '../../../../functional/states'
 import { RectType } from '../../../../functional/types'
 import { Vector2D } from '../../../../math/vector2d'
 import { Track } from '../../track'
@@ -68,15 +69,13 @@ export class Box2DLinearInterpolationPolicy extends LinearInterpolationPolicy {
 
     const shapes = this._track.getShapes(index)
     const newShapes = [
-      {
+      makeRect({
         ...shapes[0],
-        shape: {
-          x1: newCenter.x - newDimension.x / 2.,
-          x2: newCenter.x + newDimension.x / 2.,
-          y1: newCenter.y - newDimension.y / 2.,
-          y2: newCenter.y + newDimension.y / 2.
-        }
-      }
+        x1: newCenter.x - newDimension.x / 2.,
+        x2: newCenter.x + newDimension.x / 2.,
+        y1: newCenter.y - newDimension.y / 2.,
+        y2: newCenter.y + newDimension.y / 2.
+      }, false)
     ]
 
     this._track.setShapes(index, newShapes)

--- a/app/src/js/functional/states.ts
+++ b/app/src/js/functional/states.ts
@@ -116,14 +116,14 @@ export function makeShape (shapeType: string = '',
  * @param {{}} params
  * @return {RectType}
  */
-export function makeRect (params: Partial<RectType> = {}): RectType {
+export function makeRect (
+    params: Partial<RectType> = {}, newId: bool = true): RectType {
   return {
     x1: -1,
     y1: -1,
     x2: -1,
     y2: -1,
-    ...makeShape(types.ShapeTypeName.RECT),
-    ...params
+    ...makeShape(types.ShapeTypeName.RECT, params, newId)
   }
 }
 

--- a/app/src/test/components/track.test.tsx
+++ b/app/src/test/components/track.test.tsx
@@ -288,11 +288,12 @@ describe('basic track ops', () => {
         state.task.tracks[trackIds[0]].labels[i],
         { x1: 15, y1: 25, x2: 50, y2: 60 }, i)
     }
-    // Shapes before item 4 should not change
+    // Shapes before item 4 should be linearly interpolated
     for (let i = 0; i < 4; ++i) {
+      const diff = i * 1.25
       checkBox2D(
         state.task.tracks[trackIds[0]].labels[i],
-        { x1: 10, y1: 20, x2: 50, y2: 60 }, i)
+        { x1: 10 + diff, y1: 20 + diff, x2: 50, y2: 60 }, i)
     }
     dispatch(action.goToItem(6))
     drag(label2d, 50, 60, 55, 65)
@@ -304,25 +305,27 @@ describe('basic track ops', () => {
         { x1: 15, y1: 25, x2: 55, y2: 65 }, i)
     }
     for (let i = 4; i < 6; ++i) {
+      const diff = (i - 4) * 2.5
       checkBox2D(
         state.task.tracks[trackIds[0]].labels[i],
-        { x1: 15, y1: 25, x2: 50, y2: 60 }, i)
+        { x1: 15, y1: 25, x2: 50 + diff, y2: 60 + diff }, i)
     }
     // Changing location
     dispatch(action.goToItem(5))
-    drag(label2d, 110, 110, 210, 210)  // (100, 100) translation
+    drag(label2d, 110, 110, 200, 200)  // (90, 90) translation
     state = getState()
     // Locations starting from item 5 should change
     for (let i = 5; i < 8; ++i) {
       checkBox2D(
         state.task.tracks[trackIds[1]].labels[i],
-        { x1: 200, y1: 210, x2: 300, y2: 400 }, i)
+        { x1: 190, y1: 200, x2: 290, y2: 390 }, i)
     }
-    // Locations before item 5 should not change
+    // Locations before item 5 should be interpolated
     for (let i = 2; i < 5; ++i) {
+      const diff = (i - 2) * 30
       checkBox2D(
         state.task.tracks[trackIds[1]].labels[i],
-        { x1: 100, y1: 110, x2: 200, y2: 300 }, i)
+        { x1: 100 + diff, y1: 110 + diff, x2: 200 + diff, y2: 300 + diff }, i)
     }
 
   })


### PR DESCRIPTION
- [x] Use linear box position and size interpolation by default
- [x] Fix tests accordingly
- [x] Use high-level object creation API for ease of future refactoring based on types