### PR TITLE
Create a new bucket for each s3 unit test run

### DIFF
--- a/app/src/js/server/s3_storage.ts
+++ b/app/src/js/server/s3_storage.ts
@@ -27,11 +27,11 @@ export class S3Storage extends Storage {
     const error = Error(errorMsg)
     const info = dataPath.split(':')
     if (info.length < 2) {
-      throw(error)
+      throw (error)
     }
     const bucketPath = info[1].split('/')
     if (bucketPath.length < 2) {
-      throw(error)
+      throw (error)
     }
     const dataDir = path.join(...bucketPath.splice(1), '/')
     super(dataDir)
@@ -53,8 +53,10 @@ export class S3Storage extends Storage {
       new AWS.SharedIniFileCredentials(),
       new AWS.ProcessCredentials()]
 
-    this.s3 = new AWS.S3({ credentialProvider: chain,
-      httpOptions: { connectTimeout: 10000 }, maxRetries: 5 })
+    this.s3 = new AWS.S3({
+      credentialProvider: chain,
+      httpOptions: { connectTimeout: 10000 }, maxRetries: 5
+    })
   }
 
   /**
@@ -70,14 +72,25 @@ export class S3Storage extends Storage {
           LocationConstraint: this.region
         }
       }
-      await this.s3.createBucket(bucketParams).promise()
-      Logger.info('Waiting for bucket to be created.')
-      const waitParams = {
-        Bucket: this.bucketName
+      Logger.info(`Creating Bucket ${this.bucketName}`)
+      try {
+        await this.s3.createBucket(bucketParams).promise()
+      } catch (error) {
+        Logger.error(error)
       }
-      await this.s3.waitFor('bucketExists', waitParams).promise()
     }
     return
+  }
+
+  /**
+   * Remove the bucket
+   */
+  public async removeBucket (): Promise<void> {
+    const params = {
+      Bucket: this.bucketName
+    }
+    Logger.info(`Deleting Bucket ${this.bucketName}`)
+    await this.s3.deleteBucket(params).promise()
   }
 
   /**
@@ -109,7 +122,7 @@ export class S3Storage extends Storage {
 
     let dirKeys = []
     let fileKeys = []
-    for (;;) {
+    for (; ;) {
       let data
       if (continuationToken.length > 0) {
         const params = {
@@ -267,7 +280,7 @@ export class S3Storage extends Storage {
   /**
    * Checks if bucket exists
    */
-  private async hasBucket (): Promise < boolean > {
+  private async hasBucket (): Promise<boolean> {
     const params = {
       Bucket: this.bucketName
     }

--- a/app/src/test/server/s3_storage.test.ts
+++ b/app/src/test/server/s3_storage.test.ts
@@ -1,6 +1,5 @@
 import AWS from 'aws-sdk'
 import * as path from 'path'
-import { sprintf } from 'sprintf-js'
 import { index2str } from '../../js/common/util'
 import { getProjectKey, getTaskKey, hostname, now } from '../../js/server/path'
 import { S3Storage } from '../../js/server/s3_storage'
@@ -127,7 +126,7 @@ describe('test s3 storage', () => {
       for (let i = 3; i < 7; i++) {
         savePromises.push(
           storage.save(getTaskKey(projectName, index2str(i)),
-            sprintf('{"testField": "testValue%d"}', i)
+            `{"testField": "testValue${i}"}`
           )
         )
       }
@@ -238,6 +237,6 @@ function checkLoad (index: number): Promise<void> {
   return storage.load(getTaskKey(projectName, index2str(index)))
     .then((data: string) => {
       const loadedData = JSON.parse(data)
-      expect(loadedData.testField).toBe(sprintf('testValue%d', index))
+      expect(loadedData.testField).toBe(`testValue${index}`)
     })
 }

--- a/app/src/test/server/s3_storage.test.ts
+++ b/app/src/test/server/s3_storage.test.ts
@@ -10,7 +10,7 @@ const s3 = new AWS.S3()
 const projectName = 'test'
 const storageName = `${hostname()}_${now()}`
 const bucketRegion = 'us-west-2'
-const bucketName = 'scalabel-unit-test'
+const bucketName = `scalabel-test-tmp-${Date.now()}`
 let storage: S3Storage
 
 beforeAll(async () => {
@@ -127,7 +127,7 @@ describe('test s3 storage', () => {
       for (let i = 3; i < 7; i++) {
         savePromises.push(
           storage.save(getTaskKey(projectName, index2str(i)),
-           sprintf('{"testField": "testValue%d"}', i)
+            sprintf('{"testField": "testValue%d"}', i)
           )
         )
       }
@@ -152,7 +152,7 @@ describe('test s3 storage', () => {
   })
 
   test('delete', () => {
-    const key = getProjectDir(`${ projectName }/tasks`)
+    const key = getProjectDir(`${projectName}/tasks`)
     return Promise.all([
       checkTaskKey(1, true),
       checkTaskKey(0, true)
@@ -207,6 +207,7 @@ afterAll(async () => {
     }
     await s3.deleteObject(params).promise()
   }
+  await storage.removeBucket()
 }, 20000)
 
 /**
@@ -235,8 +236,8 @@ function checkProjectKey (): Promise<void> {
  */
 function checkLoad (index: number): Promise<void> {
   return storage.load(getTaskKey(projectName, index2str(index)))
-  .then((data: string) => {
-    const loadedData = JSON.parse(data)
-    expect(loadedData.testField).toBe(sprintf('testValue%d', index))
-  })
+    .then((data: string) => {
+      const loadedData = JSON.parse(data)
+      expect(loadedData.testField).toBe(sprintf('testValue%d', index))
+    })
 }


### PR DESCRIPTION
Each S3 storage testing is in a new S3 bucket to avoid bucket name conflicts between different runs. This can support running s3 storage test under different AWS accounts.