### PR TITLE
Clean up dashboard handler

### DIFF
--- a/app/src/components/dashboard_init.tsx
+++ b/app/src/components/dashboard_init.tsx
@@ -27,16 +27,12 @@ export function initDashboard (vendor?: boolean) {
   // Get params from url path.
   const searchParams = new URLSearchParams(window.location.search)
   const projectName = searchParams.get('project_name')
-  // Send the request to the back end
-  const request = JSON.stringify({
-    name: projectName
-  })
 
-  xhr.open('POST', Endpoint.DASHBOARD)
+  xhr.open('GET', `${Endpoint.DASHBOARD}?name=${projectName}`)
   xhr.setRequestHeader('Content-Type', 'application/json')
   const auth = getAuth()
   if (auth) {
     xhr.setRequestHeader('Authorization', auth)
   }
-  xhr.send(request)
+  xhr.send()
 }

--- a/app/src/const/connection.ts
+++ b/app/src/const/connection.ts
@@ -10,7 +10,7 @@ export const enum Endpoint {
   POST_PROJECT_INTERNAL = '/postProjectInternal',
   GET_PROJECT_NAMES = '/getProjectNames',
   EXPORT = '/getExport',
-  DASHBOARD = '/postDashboardContents',
+  DASHBOARD = '/getDashboardContents',
   POST_TASKS = '/postTasks',
   CALLBACK = '/callback'
 }

--- a/app/src/server/listeners.ts
+++ b/app/src/server/listeners.ts
@@ -5,7 +5,7 @@ import {
 } from 'express'
 import { File } from 'formidable'
 import _ from 'lodash'
-import { DashboardContents, TaskOptions } from '../components/dashboard'
+import { DashboardContents } from '../components/dashboard'
 import { getSubmissionTime } from '../components/util'
 import { FormField } from '../const/project'
 import { ItemExport } from '../types/bdd'
@@ -276,7 +276,7 @@ export class Listeners {
       const project = await this.projectStore.loadProject(projectName)
       const projectMetaData = getProjectOptions(project)
 
-      const savedTasks = await this.projectStore.getSavedTasks(
+      const savedTasks = await this.projectStore.loadTaskStates(
         projectName)
       const taskOptions = _.map(savedTasks, getTaskOptions)
 

--- a/app/src/server/main.ts
+++ b/app/src/server/main.ts
@@ -62,11 +62,13 @@ function startHTTPServer (
   app.use(Endpoint.CALLBACK,
     new Callback(config).router)
 
-  // Set up post/get handlers
+  // Set up get and post handlers
   app.get(Endpoint.GET_PROJECT_NAMES, authMiddleWare,
     listeners.projectNameHandler.bind(listeners))
   app.get(Endpoint.EXPORT, authMiddleWare,
    listeners.getExportHandler.bind(listeners))
+  app.get(Endpoint.DASHBOARD, authMiddleWare,
+   listeners.dashboardHandler.bind(listeners))
 
   app.post(Endpoint.POST_PROJECT, authMiddleWare, formidable(),
     listeners.postProjectHandler.bind(listeners))
@@ -74,8 +76,6 @@ function startHTTPServer (
     listeners.postProjectInternalHandler.bind(listeners))
   app.post(Endpoint.POST_TASKS, authMiddleWare, express.json(),
     listeners.postTasksHandler.bind(listeners))
-  app.post(Endpoint.DASHBOARD, authMiddleWare, express.json(),
-    listeners.dashboardHandler.bind(listeners))
   app.use(errorHandler(config))
 }
 

--- a/app/src/server/project_store.ts
+++ b/app/src/server/project_store.ts
@@ -174,10 +174,11 @@ export class ProjectStore {
   }
 
   /**
-   * Get all of the latest task data for the project
-   * If there is no saved data, returns the initial data for that task
+   * Get the latest state for each task in the project
+   * Check redis first, then memory
+   * If there is no saved state for a task, returns the initial task
    */
-  public async getSavedTasks (projectName: string): Promise<TaskType[]> {
+  public async loadTaskStates (projectName: string): Promise<TaskType[]> {
     const tasks = await this.getTasksInProject(projectName)
 
     const savedStatePromises = _.map(tasks, (emptyTask) =>
@@ -244,7 +245,7 @@ export class ProjectStore {
     if (!metaDataJSON) {
       return makeUserMetadata()
     }
-    // Handle backwards compatability
+    // Handle backwards compatibility
     const userMetadata = safeParseJSON(metaDataJSON)
     if (_.has(userMetadata, 'socketToProject')) {
       // New code saves as an object, which allows extensions

--- a/app/src/server/project_store.ts
+++ b/app/src/server/project_store.ts
@@ -174,6 +174,20 @@ export class ProjectStore {
   }
 
   /**
+   * Get all of the latest task data for the project
+   * If there is no saved data, returns the initial data for that task
+   */
+  public async getSavedTasks (projectName: string): Promise<TaskType[]> {
+    const tasks = await this.getTasksInProject(projectName)
+
+    const savedStatePromises = _.map(tasks, (emptyTask) =>
+      this.loadState(projectName, emptyTask.config.taskId))
+    const savedStates = await Promise.all(savedStatePromises)
+    const savedTasks = _.map(savedStates, (state) => state.task)
+    return savedTasks
+  }
+
+  /**
    * Saves a list of tasks
    */
   public async saveTasks (tasks: TaskType[]) {

--- a/app/src/server/util.ts
+++ b/app/src/server/util.ts
@@ -2,6 +2,7 @@
 import _ from 'lodash'
 import { configureStore } from '../common/configure_store'
 import { uid } from '../common/uid'
+import { ProjectOptions, TaskOptions } from '../components/dashboard'
 import {
   BundleFile, HandlerUrl, ItemTypeName,
   LabelTypeName, TrackPolicyType
@@ -9,7 +10,7 @@ import {
 import { StorageType } from '../const/config'
 import { BaseAction } from '../types/action'
 import { ItemExport } from '../types/bdd'
-import { CreationForm, UserData, UserMetadata } from '../types/project'
+import { CreationForm, Project, UserData, UserMetadata } from '../types/project'
 import { Label2DTemplateType, State, TaskType } from '../types/state'
 import { FileStorage } from './file_storage'
 import Logger from './logger'
@@ -71,6 +72,21 @@ export function makeCreationForm (
     instructionUrl, taskSize, demoMode
   }
   return form
+}
+
+/**
+ * Extract ProjectOption from a Project
+ */
+export function getProjectOptions (project: Project): ProjectOptions {
+  return {
+    name: project.config.projectName,
+    itemType: project.config.itemType,
+    labelTypes: project.config.labelTypes,
+    taskSize: project.config.taskSize,
+    numItems: project.items.length,
+    numLeafCategories: project.config.categories.length,
+    numAttributes: project.config.attributes.length
+  }
 }
 
 /**
@@ -167,7 +183,7 @@ export function getPolicy (
  * numLabeledItems is the number of items with at least 1 label in the task
  * numLabels is the total number of labels in the task
  */
-export function countLabels (task: TaskType): [number, number] {
+function countLabels (task: TaskType): [number, number] {
   let numLabeledItems = 0
   let numLabels = 0
   for (const item of task.items) {
@@ -178,6 +194,19 @@ export function countLabels (task: TaskType): [number, number] {
     }
   }
   return [numLabeledItems, numLabels]
+}
+
+/**
+ * Extracts TaskOptions from a Task
+ */
+export function getTaskOptions (task: TaskType): TaskOptions {
+  const [numLabeledItems, numLabels] = countLabels(task)
+  return {
+    numLabeledItems: numLabeledItems.toString(),
+    numLabels: numLabels.toString(),
+    submissions: task.progress.submissions,
+    handlerUrl: task.config.handlerUrl
+  }
 }
 
 /**


### PR DESCRIPTION
- [x] Convert to get request (does not modify state)

- [x] Move loading of tasks into the project store, so it can be reused in the near future (my next PR will need this)