### PR TITLE
Enable setting box2d distinct colors for categories

### DIFF
--- a/app/src/drawable/2d/box2d.ts
+++ b/app/src/drawable/2d/box2d.ts
@@ -5,7 +5,13 @@ import { makeLabel, makeRect } from "../../functional/states"
 import { Size2D } from "../../math/size2d"
 import { Vector2D } from "../../math/vector2d"
 import { LabelType, RectType, ShapeType, State } from "../../types/state"
-import { blendColor, Context2D, encodeControlColor } from "../util"
+import {
+  blendColor,
+  Context2D,
+  encodeControlColor,
+  isHexColor,
+  toNumColor
+} from "../util"
 import { DrawMode, Label2D } from "./label2d"
 import { Label2DList } from "./label2d_list"
 import { makePoint2DStyle, Point2D } from "./point2d"
@@ -100,6 +106,9 @@ export class Box2D extends Label2D {
     let highPointStyle = makePoint2DStyle()
     let rectStyle = makeRect2DStyle()
     let assignColor: (i: number) => number[] = () => [0]
+
+    const categoryColor: string = this._config.categoryColors[this.category[0]]
+
     switch (mode) {
       case DrawMode.VIEW:
         pointStyle = _.assign(pointStyle, DEFAULT_VIEW_POINT_STYLE)
@@ -127,10 +136,18 @@ export class Box2D extends Label2D {
 
     // Draw!!!
     const rect = this._rect
-    rectStyle.color = assignColor(0)
+    rectStyle.color =
+      isHexColor(categoryColor) && mode !== DrawMode.CONTROL
+        ? toNumColor(categoryColor)
+        : assignColor(0)
     rect.draw(context, ratio, rectStyle)
     if (mode === DrawMode.VIEW) {
-      this.drawTag(context, ratio, new Vector2D(rect.x1, rect.y1), this._color)
+      this.drawTag(
+        context,
+        ratio,
+        new Vector2D(rect.x1, rect.y1),
+        rectStyle.color
+      )
     }
     if (mode === DrawMode.CONTROL || this._selected || this._highlighted) {
       for (let i = 1; i <= 8; i += 1) {

--- a/app/src/drawable/2d/label2d.ts
+++ b/app/src/drawable/2d/label2d.ts
@@ -13,7 +13,7 @@ import {
   ShapeType,
   State
 } from "../../types/state"
-import { Context2D, getColorById } from "../util"
+import { Context2D, getColorById, reverseTextColor } from "../util"
 import { Label2DList } from "./label2d_list"
 
 export enum DrawMode {
@@ -316,7 +316,9 @@ export abstract class Label2D {
 
     ctx.fillStyle = `rgb(${fillStyle[0]}, ${fillStyle[1]}, ${fillStyle[2]})`
     ctx.fillRect(x * ratio, y * ratio - TAG_HEIGHT, tw, TAG_HEIGHT)
-    ctx.fillStyle = "rgb(0,0,0)"
+    ctx.fillStyle = reverseTextColor(fillStyle)
+      ? "rgb(255,255,255)"
+      : "rgb(0,0,0)"
     ctx.font = `${20}px Verdana`
     ctx.fillText(abbr, x * ratio + 6, y * ratio - 6)
     ctx.restore()

--- a/app/src/drawable/util.ts
+++ b/app/src/drawable/util.ts
@@ -84,10 +84,20 @@ export function getColorById(labelId: IdType, trackId: IdType): number[] {
 }
 
 /**
+ * Return true if should use white font color for better contrast
+ *
+ * @param {number[]} bgColor - background color r g b array
+ * @return boolean
+ */
+export function reverseTextColor(bgColor: number[]): boolean {
+  const [r, g, b] = bgColor
+  return r * 0.299 + g * 0.587 + b * 0.114 < 151
+}
+
+/**
  * Convert numerical color to CSS color string
  *
- * @param {number[]} color: can have 3 or 4 elements
- * @param color
+ * @param {number[]} color - can have 3 or 4 elements
  */
 export function toCssColor(color: number[]): string {
   if (color.length === 3) {
@@ -97,6 +107,31 @@ export function toCssColor(color: number[]): string {
   } else {
     throw new Error(`color argument has wrong length ${color.length}`)
   }
+}
+
+/**
+ * Return true if the string is valid CSS hex color representation
+ *
+ * @param {string} color - color string
+ * @return boolean
+ */
+export function isHexColor(color: string): boolean {
+  return /^#[0-9A-F]{6}$/i.test(color)
+}
+
+/**
+ * Convert CSS hex color string to numerical color
+ *
+ * @param {string} color - hex color string
+ * @return [number, number, number]
+ */
+export function toNumColor(color: string): number[] {
+  const hex = color.replace(/[^0-9A-F]/gi, "")
+  const bigint = parseInt(hex, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return [r, g, b]
 }
 
 export type Context2D = CanvasRenderingContext2D

--- a/app/src/functional/states.ts
+++ b/app/src/functional/states.ts
@@ -500,6 +500,7 @@ export function makeTaskConfig(params: Partial<ConfigType> = {}): ConfigType {
     instructionPage: "", // Instruction url
     bundleFile: "",
     categories: [],
+    categoryColors: [],
     attributes: [],
     taskId: "",
     demoMode: false,

--- a/app/src/server/create_project.ts
+++ b/app/src/server/create_project.ts
@@ -97,6 +97,8 @@ export async function parseForm(
 type Categories = Array<{
   /** Name of the category */
   name: string
+  /** Color for category */
+  color: string
 }>
 
 /**
@@ -156,16 +158,20 @@ export async function parseFiles(
     ) => {
       const categoriesData = result[4]
       const categoriesList = []
+      const categoryColors = []
       for (const category of categoriesData) {
         categoriesList.push(category.name)
+        categoryColors.push(category.color)
       }
-      return {
+      const formFileData = {
         items: result[0],
         sensors: result[1],
         templates: result[2],
         attributes: result[3],
-        categories: categoriesList
+        categories: categoriesList,
+        categoryColors: categoryColors
       }
+      return formFileData
     }
   )
 }
@@ -286,6 +292,7 @@ export async function createProject(
     instructionPage: form.instructionUrl,
     bundleFile,
     categories: formFileData.categories,
+    categoryColors: formFileData.categoryColors,
     attributes: formFileData.attributes,
     taskId: "",
     tracking,

--- a/app/src/server/defaults.ts
+++ b/app/src/server/defaults.ts
@@ -49,7 +49,8 @@ const boxCategoriesList = [
   "traffic light"
 ]
 export const boxCategories = boxCategoriesList.map((category) => ({
-  name: category
+  name: category,
+  color: ""
 }))
 
 /* default categories when file is missing and label is polyline2d */
@@ -64,7 +65,7 @@ export const polyline2DCategoriesList = [
   "crosswalk"
 ]
 export const polyline2DCategories = polyline2DCategoriesList.map(
-  (category) => ({ name: category })
+  (category) => ({ name: category, color: "" })
 )
 
 // TODO: add default seg2d categories once nested categories are supported

--- a/app/src/types/project.ts
+++ b/app/src/types/project.ts
@@ -37,6 +37,8 @@ export interface CreationForm {
 export interface FormFileData {
   /** categories parsed from form file */
   categories: string[]
+  /** category colors parsed from form file */
+  categoryColors: string[]
   /** sensors */
   sensors: SensorType[]
   /** custom label template */

--- a/app/src/types/state.ts
+++ b/app/src/types/state.ts
@@ -345,6 +345,8 @@ export interface ConfigType {
   bundleFile: string
   /** Categories */
   categories: string[]
+  /** Category colors */
+  categoryColors: string[]
   /** Attributes */
   attributes: Attribute[]
   /** task id */

--- a/app/test/test_states/test_creation_objects.ts
+++ b/app/test/test_states/test_creation_objects.ts
@@ -29,6 +29,19 @@ const sampleCategories: string[] = [
   "traffic light"
 ]
 
+const sampleCategoryColors: string[] = [
+  "#0000ff",
+  "#5fbdff",
+  "#660000",
+  "#FF4400",
+  "#ff3aff",
+  "#ff0000",
+  "#ff9cc3",
+  "#22ffff",
+  "#00FF00",
+  "#FFFFFF"
+]
+
 const sampleAttributes: Array<Partial<Attribute>> = [
   {
     name: "Occluded",
@@ -170,6 +183,7 @@ export const sampleFormVideo: CreationForm = {
 
 export const sampleFormFileData: FormFileData = {
   categories: sampleCategories,
+  categoryColors: sampleCategoryColors,
   attributes: sampleAttributes as Attribute[],
   sensors: [],
   items: sampleItems,
@@ -191,6 +205,7 @@ export const sampleProjectImage: Project = {
     instructionPage: sampleInstructions,
     bundleFile: BundleFile.V2,
     categories: sampleCategories,
+    categoryColors: sampleCategoryColors,
     attributes: sampleAttributes as Attribute[],
     taskId: "",
     demoMode: false,
@@ -250,6 +265,7 @@ sampleItemsVideo[1].labels = [
 
 export const sampleVideoFormFileData: FormFileData = {
   categories: sampleCategories,
+  categoryColors: sampleCategoryColors,
   attributes: sampleAttributes as Attribute[],
   items: sampleItemsVideo,
   sensors: [],
@@ -271,6 +287,7 @@ export const sampleProjectVideo: Project = {
     instructionPage: sampleInstructions,
     bundleFile: BundleFile.V1,
     categories: sampleCategories,
+    categoryColors: sampleCategoryColors,
     attributes: sampleAttributes as Attribute[],
     taskId: "",
     demoMode: true,
@@ -295,6 +312,7 @@ export const sampleProjectAutolabel: Project = {
     instructionPage: sampleInstructions,
     bundleFile: BundleFile.V2,
     categories: sampleCategories,
+    categoryColors: sampleCategoryColors,
     attributes: sampleAttributes as Attribute[],
     taskId: "",
     demoMode: false,
@@ -319,6 +337,7 @@ export const sampleProjectAutolabelPolygon: Project = {
     instructionPage: sampleInstructions,
     bundleFile: BundleFile.V2,
     categories: sampleCategories,
+    categoryColors: sampleCategoryColors,
     attributes: sampleAttributes as Attribute[],
     taskId: "",
     demoMode: false,
@@ -343,6 +362,7 @@ export const sampleTasksImage: TaskType[] = [
       instructionPage: sampleInstructions,
       bundleFile: BundleFile.V2,
       categories: sampleCategories,
+      categoryColors: sampleCategoryColors,
       attributes: sampleAttributes as Attribute[],
       taskId: "000000",
       demoMode: false,
@@ -437,6 +457,7 @@ export const sampleTasksImage: TaskType[] = [
       instructionPage: sampleInstructions,
       bundleFile: BundleFile.V2,
       categories: sampleCategories,
+      categoryColors: sampleCategoryColors,
       attributes: sampleAttributes as Attribute[],
       taskId: "000001",
       demoMode: false,
@@ -534,6 +555,7 @@ export const sampleTasksVideo: TaskType[] = [
       instructionPage: "instructions.com",
       bundleFile: "image.js",
       categories: sampleCategories,
+      categoryColors: sampleCategoryColors,
       attributes: sampleAttributes as Attribute[],
       taskId: "000000",
       demoMode: true,
@@ -694,6 +716,7 @@ export const sampleTasksVideo: TaskType[] = [
       instructionPage: "instructions.com",
       bundleFile: "image.js",
       categories: sampleCategories,
+      categoryColors: sampleCategoryColors,
       attributes: sampleAttributes as Attribute[],
       taskId: "000001",
       demoMode: true,

--- a/examples/drivable_area_categories_with_colors.yml
+++ b/examples/drivable_area_categories_with_colors.yml
@@ -1,0 +1,4 @@
+- name: drivable
+  color: "#00ff00"
+- name: alternative
+  color: "#0000ff"

--- a/examples/drivable_area_categories_with_incorrect_colors.yml
+++ b/examples/drivable_area_categories_with_incorrect_colors.yml
@@ -1,0 +1,4 @@
+- name: drivable
+  color: "wrong"
+- name: alternative
+  color: "#color"


### PR DESCRIPTION
Enable setting box2d distinct colors for categories
Color is provided in CSS format: 
```
- name: drivable
  color: "#00ff00"
- name: alternative
  color: "#0000ff"
```
shortened variant (like "#0f0") is not supported.

![Снимок экрана от 2021-04-25 17-32-25](https://user-images.githubusercontent.com/5877402/115997638-80ff1e00-a5ec-11eb-9ff2-6fe9dcd541ef.png)
