### PR TITLE
Fix highlighting of toolbar buttons for image tags

### DIFF
--- a/app/src/components/toolbar.tsx
+++ b/app/src/components/toolbar.tsx
@@ -271,16 +271,18 @@ export class ToolBar extends Component<Props> {
       LabelTypeName.TAG
     ) {
       const item = state.task.items[state.user.select.item]
-      const labelId = Number(_.findKey(item.labels))
-      if (isNaN(labelId)) {
+      const labelId = _.findKey(item.labels)
+      if (labelId === undefined) {
         return 0
       }
-      const attributes = item.labels[labelId].attributes
+      const attributes = isNaN(Number(labelId))
+        ? item.labels[labelId].attributes
+        : item.labels[parseInt(labelId, 10)].attributes
       const index = this.getAttributeIndex(state.task.config.attributes, name)
       if (index < 0) {
         return 0
       }
-      if (attributes[index].length > 0) {
+      if (attributes[index] !== undefined && attributes[index].length > 0) {
         return attributes[index][0]
       } else {
         return 0

--- a/app/src/components/toolbar_list_button.tsx
+++ b/app/src/components/toolbar_list_button.tsx
@@ -70,9 +70,7 @@ class ToggleButtons extends React.Component<Props> {
         <ListItem dense={true} className={classes.toggleContainer}>
           <ToggleButtonGroup
             className={classes.buttonGroup}
-            value={
-              this.props.values[this.props.getAlignmentIndex(this.props.name)]
-            }
+            value={values[this.props.getAlignmentIndex(name)]}
             exclusive
             onChange={this.handleAlignment}
           >


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/5877402/115998526-52834200-a5f0-11eb-8c6c-f27234f0bf55.png)

After: 
![image](https://user-images.githubusercontent.com/5877402/115998814-b6f2d100-a5f1-11eb-8b54-76ed417775e8.png)
