### PR TITLE
Assign hotkeys to image tags and box2d categories

### DIFF
--- a/app/src/common/label.tsx
+++ b/app/src/common/label.tsx
@@ -15,6 +15,7 @@ import { AttributeToolType } from "../const/common"
  * @param getAlignmentIndex
  * @param {string} name
  * @param {string[]} options
+ * @param {string[]} hotKeys
  */
 export function renderTemplate(
   toolType: string,
@@ -22,7 +23,8 @@ export function renderTemplate(
   handleAttributeToggle: (toggleName: string, alignment: string) => void,
   getAlignmentIndex: (switName: string) => number,
   name: string,
-  options: string[]
+  options: string[],
+  hotKeys: string[] | null
 ): React.ReactNode {
   if (toolType === AttributeToolType.SWITCH) {
     return (
@@ -40,6 +42,7 @@ export function renderTemplate(
           values={options}
           handleAttributeToggle={handleAttributeToggle}
           getAlignmentIndex={getAlignmentIndex}
+          hotKeys={hotKeys}
         />
       </ListItem>
     )

--- a/app/src/components/toolbar.tsx
+++ b/app/src/components/toolbar.tsx
@@ -17,7 +17,12 @@ import {
 import { addLabelTag } from "../action/tag"
 import { renderTemplate } from "../common/label"
 import Session from "../common/session"
-import { Key, LabelTypeName } from "../const/common"
+import {
+  AttributeToolType,
+  AvailableHotKeys,
+  Key,
+  LabelTypeName
+} from "../const/common"
 import { getSelectedTracks } from "../functional/state_util"
 import { isValidId } from "../functional/states"
 import { tracksOverlapping } from "../functional/track"
@@ -35,6 +40,7 @@ interface Props {
   /** labelType of ToolBar 'box2d' | 'polygon2d' | 'lane' */
   labelType: string
 }
+
 /**
  * This is ToolBar component that displays
  * all the attributes and categories for the 2D bounding box labeling tool
@@ -46,6 +52,25 @@ export class ToolBar extends Component<Props> {
   private readonly _keyDownHandler: (e: KeyboardEvent) => void
   /** key up handler */
   private readonly _keyUpHandler: (e: KeyboardEvent) => void
+
+  /**
+   * Return array of hotkey tip chars
+   *
+   * @param {number} index - index of current attribute element in categories list
+   * @param {Attribute} element - attribute element
+   */
+  private hotKeys(index: number, element: Attribute): string[] | null {
+    const state = this.state
+    if (
+      element.toolType !== AttributeToolType.LIST ||
+      state.task.config.labelTypes[state.user.select.labelType] !==
+        LabelTypeName.TAG ||
+      index > 3
+    ) {
+      return null
+    }
+    return AvailableHotKeys[index].slice(0, element.values.length)
+  }
 
   /**
    * Constructor
@@ -126,7 +151,7 @@ export class ToolBar extends Component<Props> {
           <Category categories={categories} headerText={"Category"} />
         ) : null}
         <List>
-          {attributes.map((element: Attribute) => (
+          {attributes.map((element: Attribute, index: number) => (
             <React.Fragment key={element.name}>
               {renderTemplate(
                 element.toolType,
@@ -134,7 +159,8 @@ export class ToolBar extends Component<Props> {
                 this.handleAttributeToggle,
                 this.getAlignmentIndex,
                 element.name,
-                element.values
+                element.values,
+                this.hotKeys(index, element)
               )}
             </React.Fragment>
           ))}

--- a/app/src/components/toolbar_category.tsx
+++ b/app/src/components/toolbar_category.tsx
@@ -20,8 +20,8 @@ import { Component } from "./component"
  * @param _event
  * @param categoryIndex
  */
-function handleChange(
-  _event: React.MouseEvent<HTMLElement>,
+export function handleChange(
+  _event: React.MouseEvent<HTMLElement> | null,
   categoryIndex: number | null
 ): void {
   const state = getState()
@@ -99,7 +99,7 @@ class MultipleSelect extends Component<Props> {
                 value={index}
                 disableRipple={true}
               >
-                {name}
+                {name} {index < 9 ? `[${index + 1}]` : ""}
               </ToggleButton>
             ))}
           </ToggleButtonGroup>

--- a/app/src/components/toolbar_list_button.tsx
+++ b/app/src/components/toolbar_list_button.tsx
@@ -32,6 +32,8 @@ interface Props {
   name: string
   /** values of ToggleButtons */
   values: string[]
+  /** button hotkey tip values array */
+  hotKeys: string[] | null
 }
 
 /**
@@ -58,7 +60,7 @@ class ToggleButtons extends React.Component<Props> {
 
   /** render function of ToggleButtons */
   public render(): JSX.Element {
-    const { name, classes, values } = this.props
+    const { name, classes, values, hotKeys } = this.props
     const ToggleBtn = withStyles(toggleButtonStyle)(ToggleButton)
     return (
       <List style={{ width: "100%", padding: "0px" }}>
@@ -76,7 +78,7 @@ class ToggleButtons extends React.Component<Props> {
             exclusive
             onChange={this.handleAlignment}
           >
-            {values.map((element: string) => (
+            {values.map((element: string, index: number) => (
               <ToggleBtn
                 className={classes.toggleButton}
                 value={element}
@@ -84,7 +86,8 @@ class ToggleButtons extends React.Component<Props> {
                 data-testid={"toggle-button-" + element}
               >
                 {" "}
-                {element}{" "}
+                {element}
+                {hotKeys?.[index] !== undefined ? ` [${hotKeys[index]}] ` : " "}
               </ToggleBtn>
             ))}
           </ToggleButtonGroup>

--- a/app/src/const/common.ts
+++ b/app/src/const/common.ts
@@ -160,3 +160,48 @@ export enum QueryArg {
   TASK_INDEX = "task_index",
   DEV_MODE = "dev"
 }
+
+export const AvailableHotKeys = [
+  ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+  ["Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"],
+  ["A", "S", "D", "F", "G", "H", "J", "K", "L"],
+  ["Z", "X", "C", "V", "B", "N", "M"]
+]
+
+export const AvailableHotKeyCodes = [
+  [
+    "Digit1",
+    "Digit2",
+    "Digit3",
+    "Digit4",
+    "Digit5",
+    "Digit6",
+    "Digit7",
+    "Digit8",
+    "Digit9"
+  ],
+  [
+    "KeyQ",
+    "KeyW",
+    "KeyE",
+    "KeyR",
+    "KeyT",
+    "KeyY",
+    "KeyU",
+    "KeyI",
+    "KeyO",
+    "KeyP"
+  ],
+  [
+    "KeyA",
+    "KeyS",
+    "KeyD",
+    "KeyF",
+    "KeyG",
+    "KeyH",
+    "KeyJ",
+    "KeyK",
+    "KeyL"
+  ],
+  ["KeyZ", "KeyX", "KeyC", "KeyV", "KeyB", "KeyN", "KeyM"]
+]

--- a/app/test/components/toolbar.test.tsx
+++ b/app/test/components/toolbar.test.tsx
@@ -133,6 +133,7 @@ describe("test functionality for attributes with multiple values", () => {
         values={testValues}
         handleAttributeToggle={dummyAttributeToggle}
         getAlignmentIndex={dummyGetAlignmentIndex}
+        hotKeys={["1", "2", "3"]}
       />
     )
     expect(handleToggleWasCalled).toBe(false)
@@ -146,6 +147,7 @@ describe("test functionality for attributes with multiple values", () => {
         values={testValues}
         handleAttributeToggle={dummyAttributeToggle}
         getAlignmentIndex={dummyGetAlignmentIndex}
+        hotKeys={["Q", "W", "E", "R", "T", "Y"]}
       />
     )
     let AButton = getByTestId("toggle-button-A") as HTMLButtonElement


### PR DESCRIPTION
Hotkeys allow to speed up annotation, especially for image tagging

![image](https://user-images.githubusercontent.com/5877402/115999748-a04e7900-a5f5-11eb-8b18-87919d16912a.png)

![image](https://user-images.githubusercontent.com/5877402/115999764-afcdc200-a5f5-11eb-80db-ebc0aea95da3.png)
