### PR TITLE
Show all attributes values on box2d labels

### DIFF
--- a/app/src/drawable/2d/label2d.ts
+++ b/app/src/drawable/2d/label2d.ts
@@ -294,23 +294,16 @@ export abstract class Label2D {
 
     for (const attributeId of Object.keys(attributes)) {
       const attribute = config.attributes[Number(attributeId)]
+      const attrValue = attributes[Number(attributeId)][0]
+      if (attrValue <= 0) {
+        continue
+      }
+      abbr += "," + attribute.tagText
       if (attribute.toolType === "switch") {
-        if (attributes[Number(attributeId)][0] > 0) {
-          abbr += "," + attribute.tagText
-          tw += 36
-        }
+        tw += 36
       } else if (attribute.toolType === "list") {
-        if (
-          Number(attributeId) in attribute &&
-          attributes[Number(attributeId)][0] > 0
-        ) {
-          abbr +=
-            "," +
-            attribute.tagText +
-            ":" +
-            attribute.tagSuffixes[attributes[Number(attributeId)][0]]
-          tw += 72
-        }
+        abbr += ":" + attribute.tagSuffixes[attrValue]
+        tw += 72
       }
     }
 
@@ -430,7 +423,7 @@ export abstract class Label2D {
     )
     this.setSelected(
       this._label.item in select.labels &&
-        select.labels[this._label.item].includes(labelId)
+      select.labels[this._label.item].includes(labelId)
     )
     this.updateShapes(this._label.shapes.map((i) => item.shapes[i]))
   }


### PR DESCRIPTION
I don't know why it was disabled by a condition, which was usually falsey. But we needed to see these values (like Traffic Light Color in the example), so I think that their absence is a bug.

Before:
![image](https://user-images.githubusercontent.com/5877402/116002537-da724780-a602-11eb-9617-1fd8cf761f5b.png)

After:
![image](https://user-images.githubusercontent.com/5877402/116002605-363cd080-a603-11eb-9a0e-0f746e9a333b.png)
