### PR TITLE
Fix misleading error msg when 'inputs' not exists in load

### DIFF
--- a/scalabel/label/io.py
+++ b/scalabel/label/io.py
@@ -21,6 +21,9 @@ def parse(raw_frame: DictStrAny) -> Frame:
 def load(inputs: str, nprocs: int = 0) -> List[Frame]:
     """Load labels from a json file or a folder of json files."""
     raw_frames: List[DictStrAny] = []
+    if not osp.exists(inputs):
+        raise FileNotFoundError(f"{inputs} does not exist.")
+
     if osp.isfile(inputs) and inputs.endswith("json"):
         with open(inputs, "r") as fp:
             content = json.load(fp)


### PR DESCRIPTION
The load function will raise a Value error with message "Inputs must be a folder or a JSON file." when it actually should raise a FileNotFoundError.