### PR TITLE
add eval examples to doc, raise ValueError if no config is available

### DIFF
--- a/doc/src/eval.rst
+++ b/doc/src/eval.rst
@@ -9,9 +9,15 @@ corresponding ground truth annotations in Scalabel format.
 Detection
 -----------------
 The detection evaluation uses the AP metric and follows the protocol defined
-in the COCO dataset. You can start the evaluation by running:
+in the COCO dataset. You can start the evaluation by running, e.g.:
 
-``python3 -m scalabel.eval.detect <args>``
+.. code-block:: bash
+
+    python3 -m scalabel.eval.detect \
+        --gt scalabel/eval/testcases/track_sample_anns.json \
+        --result scalabel/eval/testcases/bbox_predictions.json \
+        --config scalabel/eval/testcases/configs.toml
+
 
 Available arguments:
 
@@ -32,9 +38,14 @@ Available arguments:
 Multi-object Tracking
 ----------------------
 The MOT evaluation uses the CLEAR MOT metrics. You can start the evaluation
-by running:
+by running, e.g.:
 
-``python3 -m scalabel.eval.mot <args>``
+.. code-block:: bash
+
+    python3 -m scalabel.eval.mot \
+        --gt scalabel/eval/testcases/track_sample_anns.json \
+        --result scalabel/eval/testcases/track_predictions.json \
+        --config scalabel/eval/testcases/configs.toml
 
 Available arguments:
 

--- a/scalabel/eval/detect.py
+++ b/scalabel/eval/detect.py
@@ -278,5 +278,9 @@ if __name__ == "__main__":
     preds = load(args.result).frames
     if args.config is not None:
         cfg = load_label_config(args.config)
-    assert cfg is not None
+    if cfg is None:
+        raise ValueError(
+            "Dataset config is not specified. Please use --config"
+            " to specify a config for this dataset."
+        )
     evaluate_det(gts, preds, cfg, args.out_dir)

--- a/scalabel/eval/mot.py
+++ b/scalabel/eval/mot.py
@@ -366,7 +366,11 @@ if __name__ == "__main__":
     gt_frames, cfg = dataset.frames, dataset.config
     if args.config is not None:
         cfg = load_label_config(args.config)
-    assert cfg is not None
+    if cfg is None:
+        raise ValueError(
+            "Dataset config is not specified. Please use --config"
+            " to specify a config for this dataset."
+        )
     scores = evaluate_track(
         acc_single_video_mot,
         group_and_sort(gt_frames),

--- a/scalabel/label/to_coco.py
+++ b/scalabel/label/to_coco.py
@@ -471,7 +471,11 @@ def run(args: argparse.Namespace) -> None:
 
     if args.config is not None:
         config = load_label_config(args.config)
-    assert config is not None
+    if config is None:
+        raise ValueError(
+            "Dataset config is not specified. Please use --config"
+            " to specify a config for this dataset."
+        )
 
     logger.info("Start format converting...")
     if args.mode in ["det", "box_track"]:


### PR DESCRIPTION
Add examples for evaluation code with testcase files to documentation, raise ValueError if no config available (both dataset & commandl line).