### PR TITLE
add bool to the VideoFunc definition

### DIFF
--- a/scalabel/eval/mot.py
+++ b/scalabel/eval/mot.py
@@ -26,7 +26,7 @@ from ..label.utils import (
 EvalResults = Dict[str, Dict[str, float]]
 Video = TypeVar("Video", List[Frame], List[str])
 VidFunc = Callable[
-    [Video, Video, List[str], float, float],
+    [Video, Video, List[str], float, float, bool],
     List[mm.MOTAccumulator],
 ]
 
@@ -339,7 +339,14 @@ def evaluate_track(
             )
     else:
         accs = [
-            acc_single_video(gt, result, class_names, iou_thr, ignore_iof_thr)
+            acc_single_video(
+                gt,
+                result,
+                class_names,
+                iou_thr,
+                ignore_iof_thr,
+                ignore_unknown_cats,
+            )
             for gt, result in zip(gts, results)
         ]
 


### PR DESCRIPTION
One new param was added to the function `acc_single_video_mot` in [PR 328](https://github.com/scalabel/scalabel/pull/328).
This function will be used as a parameter (with typing `VideoFunc`) for the function `evaluation_track`.

However, the definition `VideoFunc` lacks a corresponding re-definition.
This static error was not detected by mypy.