### PR TITLE
Checking for self-intersecting polygons

### DIFF
--- a/app/src/math/poly_complex.ts
+++ b/app/src/math/poly_complex.ts
@@ -1,0 +1,118 @@
+import { Project } from "../types/project"
+import Logger from "../server/logger"
+
+/**
+ * Checks all imported polygons and removes them if they have self-intersections
+ *
+ * @param project
+ */
+export default function filterPolygons(project: Project): [Project, string] {
+  let msg: string = ""
+  let count = 0
+  const filteredLabels = []
+  for (const [itemIndex, item] of project.items.entries()) {
+    if (item.labels !== undefined) {
+      for (const label of item.labels) {
+        if (label.poly2d !== null) {
+          let intersectionData = []
+          for (const poly of label.poly2d) {
+            intersectionData = polyIsComplex(poly.vertices)
+            if (intersectionData.length > 0) {
+              count += intersectionData.length
+              for (const seg of intersectionData) {
+                msg += `segment (${seg[0]}, ${seg[1]}, ${seg[2]}, ${
+                  seg[3]
+                }) intersects with segment (${seg[4]}, ${seg[5]}, ${seg[6]}, ${
+                  seg[7]
+                }) with polygon ID: ${label.id.toString()} in image with URL: ${
+                  item.url !== undefined ? item.url.toString() : ""
+                }\n`
+              }
+            } else {
+              // Only keep valid polygons
+              filteredLabels.push(label)
+            }
+          }
+        }
+      }
+    }
+
+    project.items[itemIndex].labels = filteredLabels
+  }
+
+  if (count > 0) {
+    msg =
+      `Found ${count} polygon intersection(s)!\n` +
+      msg +
+      "\nPlease check your import data."
+    Logger.warning(msg)
+  }
+
+  return [project, msg]
+}
+
+/**
+ * Determines if polygon has self-intersections and identifies all self-intersection coordinates
+ *
+ * @param vertices
+ */
+export function polyIsComplex(vertices: number[][]): number[][] {
+  const intersections: number[][] = []
+
+  for (let i = 0; i < vertices.length - 1; i++) {
+    for (let j = i + 1; j < vertices.length - 1; j++) {
+      if (
+        intersects(
+          vertices[i],
+          vertices[i + 1],
+          vertices[j],
+          vertices[j + 1]
+        ) &&
+        j - i !== 1 &&
+        j - i !== vertices.length - 2
+      ) {
+        intersections.push([
+          vertices[i][0],
+          vertices[i][1],
+          vertices[i + 1][0],
+          vertices[i + 1][1],
+          vertices[j][0],
+          vertices[j][1],
+          vertices[j + 1][0],
+          vertices[j + 1][1]
+        ])
+      }
+    }
+  }
+
+  return intersections
+}
+
+/**
+ * Determines if two lines intersect
+ *
+ * @param v1
+ * @param v2
+ * @param v3
+ * @param v4
+ */
+function intersects(
+  v1: number[],
+  v2: number[],
+  v3: number[],
+  v4: number[]
+): boolean {
+  const det =
+    (v2[0] - v1[0]) * (v4[1] - v3[1]) - (v4[0] - v3[0]) * (v2[1] - v1[1])
+  if (det === 0) {
+    return false
+  } else {
+    const lambda =
+      ((v4[1] - v3[1]) * (v4[0] - v1[0]) + (v3[0] - v4[0]) * (v4[1] - v1[1])) /
+      det
+    const gamma =
+      ((v1[1] - v2[1]) * (v4[0] - v1[0]) + (v2[0] - v1[0]) * (v4[1] - v1[1])) /
+      det
+    return lambda >= 0 && lambda <= 1 && gamma >= 0 && gamma <= 1
+  }
+}

--- a/app/src/server/logger.ts
+++ b/app/src/server/logger.ts
@@ -68,6 +68,20 @@ class Logger {
   }
 
   /**
+   * print warnings
+   *
+   * @param warn
+   */
+  public warning(warn: string): void {
+    if (warn !== undefined && !this._silent) {
+      this._logger.log({
+        level: "warn",
+        message: warn
+      })
+    }
+  }
+
+  /**
    * print informative messages
    *
    * @param message

--- a/app/test/math/poly_complex.test.ts
+++ b/app/test/math/poly_complex.test.ts
@@ -1,0 +1,64 @@
+import { polyIsComplex } from "../../src/math/poly_complex"
+
+test("Test for complex polygons correctness", () => {
+  expect(
+    polyIsComplex([
+      [10, 10],
+      [20, 10],
+      [20, 20],
+      [10, 20],
+      [10, 10]
+    ])
+  ).toEqual(expect.arrayContaining([]))
+  expect(
+    polyIsComplex([
+      [895.4950561523438, 418.41326904296875],
+      [895.4950561523438, 474.0956115722656],
+      [981.058837890625, 474.0956115722656],
+      [981.058837890625, 418.41326904296875],
+      [895.4950561523438, 418.41326904296875]
+    ])
+  ).toEqual(expect.arrayContaining([]))
+  expect(
+    polyIsComplex([
+      [10, 10],
+      [20, 10],
+      [10, 20],
+      [20, 20],
+      [10, 10]
+    ])
+  ).toEqual(expect.arrayContaining([[20, 10, 10, 20, 20, 20, 10, 10]]))
+  expect(
+    polyIsComplex([
+      [895.4950561523438, 418.41326904296875],
+      [981.058837890625, 474.0956115722656],
+      [895.4950561523438, 474.0956115722656],
+      [981.058837890625, 418.41326904296875],
+      [895.4950561523438, 418.41326904296875]
+    ])
+  ).toEqual(
+    expect.arrayContaining([
+      [
+        895.4950561523438,
+        418.41326904296875,
+        981.058837890625,
+        474.0956115722656,
+        895.4950561523438,
+        474.0956115722656,
+        981.058837890625,
+        418.41326904296875
+      ]
+    ])
+  )
+})
+
+test("Test for complex polygons speed", () => {
+  const vertices: number[][] = [[]]
+  for (let i = 0; i < 10000; i++) {
+    vertices.push([Math.random() * 100, Math.random() * 100])
+  }
+  const start = performance.now()
+  polyIsComplex(vertices)
+  const end = performance.now()
+  expect(start - end).toBeLessThan(1000)
+})

--- a/examples/image_list_poly2d.json
+++ b/examples/image_list_poly2d.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/frames/intersection-0000051.jpg",
+    "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/frames/intersection-0000051.jpg",
+    "videoName": "",
+    "attributes": null,
+    "timestamp": 10000,
+    "index": 0,
+    "labels": [
+      {
+        "id": 0,
+        "category": "car",
+        "attributes": {
+          "Occluded": false,
+          "Traffic Light Color": [0, "NA"],
+          "Truncated": false
+        },
+        "manualShape": false,
+        "box2d": null,
+        "poly2d": [
+          {
+            "vertices": [
+              [895.4950561523438, 418.41326904296875],
+              [981.058837890625, 474.0956115722656],
+              [895.4950561523438, 474.0956115722656],
+              [981.058837890625, 418.41326904296875],
+              [895.4950561523438, 418.41326904296875]
+            ],
+            "types": "LLLLL",
+            "closed": true
+          }
+        ],
+        "box3d": null
+      },
+      {
+        "id": 1,
+        "category": "car",
+        "attributes": {
+          "Occluded": false,
+          "Traffic Light Color": [0, "NA"],
+          "Truncated": false
+        },
+        "manualShape": false,
+        "box2d": null,
+        "poly2d": [
+          {
+            "vertices": [
+              [10, 10],
+              [20, 10],
+              [20, 20],
+              [10, 20],
+              [10, 10]
+            ],
+            "types": "LLLLL",
+            "closed": true
+          }
+        ],
+        "box3d": null
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Description
Fixes issue where self-intersecting polygons are erroneously imported from a label file

## Features
- Uses brute force mathematical approach to check every edge of a polygon with others to determine if it is self-intersecting
  - O(n<sup>2</sup>) time complexity, can check 10k edges in under 1s
  - Simple but sufficient for a basic check
- Displays a warning upon create project submission with:
  - Number of intersections
  - Coordinates of segments of intersections
  - Polygon ID
  - Image URL
![image](https://user-images.githubusercontent.com/47574881/135339395-0359a308-3990-42b4-8410-0f3771fd7394.png)
- Self-intersecting polygons are removed and not displayed in the annotation interface


