### PR TITLE
Show box dimensions on hover in select mode

### DIFF
--- a/app/src/drawable/2d/rect2d.ts
+++ b/app/src/drawable/2d/rect2d.ts
@@ -169,6 +169,21 @@ export class Rect2D {
     const real = this.vector().scale(ratio)
     context.rect(real[0], real[1], real[2], real[3])
     if (mode === DrawMode.VIEW) {
+      // Display box dimensions if text fits
+      if (real[2] >= 280 && real[3] >= 50) {
+        context.fillStyle = "#000000"
+        context.font = "36px Arial"
+        context.textAlign = "center"
+        context.textBaseline = "middle"
+        context.fillText(
+          `W: ${Math.round(real[2])}, H: ${Math.round(real[3])}`,
+          real[0] + real[2] / 2,
+          real[1] + real[3] / 2
+        )
+        // Reset alignment to defaults
+        context.textAlign = "start"
+        context.textBaseline = "alphabetic"
+      }
       context.fillStyle = toCssColor(style.color.concat(OPACITY))
     } else {
       context.fillStyle = toCssColor(style.color)


### PR DESCRIPTION
## Features
- Discussed with @Scalsol 
- In select mode, when hovering/selecting a 2d box, display the box dimensions in the center of the box (text font is 36px Arial, Black)
- If the text does not fit inside the box, nothing is shown (see second image)

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/10598816/139886771-9084fbd2-67c5-4a65-8044-b168786c7f5f.png">

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/10598816/139886259-f142b441-61a2-4cb7-86cd-58bbcf89ee92.png">
