### PR TITLE
3d import export

### DIFF
--- a/app/src/server/bdd_type_transformers.ts
+++ b/app/src/server/bdd_type_transformers.ts
@@ -38,9 +38,35 @@ export function transformBox3D(shape: types.ShapeType): bdd.Box3DType {
   }
   const box3d = shape as types.CubeType
   return {
-    center: box3d.center,
-    size: box3d.size,
-    orientation: box3d.orientation
+    location: [box3d.center.x, box3d.center.y, box3d.center.z],
+    dimension: [box3d.size.x, box3d.size.y, box3d.size.z],
+    orientation: [box3d.orientation.x, box3d.orientation.y, box3d.orientation.z]
+  }
+}
+
+/**
+ * Transform exported 3d box to internal cube
+ *
+ * @param box3d
+ */
+export function box3dToCube(box3d: bdd.Box3DType): types.SimpleCube {
+  return {
+    size: {
+      x: box3d.dimension[0],
+      y: box3d.dimension[1],
+      z: box3d.dimension[2]
+    },
+    orientation: {
+      x: box3d.orientation[0],
+      y: box3d.orientation[1],
+      z: box3d.orientation[2]
+    },
+    center: {
+      x: box3d.location[0],
+      y: box3d.location[1],
+      z: box3d.location[2]
+    },
+    anchorIndex: 0
   }
 }
 
@@ -61,5 +87,84 @@ export function transformPlane3D(shape: types.ShapeType): bdd.Plane3DType {
   return {
     center: plane.center,
     orientation: plane.orientation
+  }
+}
+
+/**
+ * Transform internal intrinsic parameters to export type
+ *
+ * @param intrinsics
+ */
+export function intrinsicsToExport(
+  intrinsics: types.IntrinsicsType
+): bdd.IntrinsicsExportType {
+  return {
+    focal: [intrinsics.focalLength.x, intrinsics.focalLength.y],
+    center: [intrinsics.focalCenter.x, intrinsics.focalCenter.y]
+  }
+}
+
+/**
+ * Transform exported intrinsics to internal type
+ *
+ * @param intrinsicsExport
+ */
+export function intrinsicsFromExport(
+  intrinsicsExport: bdd.IntrinsicsExportType
+): types.IntrinsicsType {
+  return {
+    focalLength: {
+      x: intrinsicsExport.focal[0],
+      y: intrinsicsExport.focal[1]
+    },
+    focalCenter: {
+      x: intrinsicsExport.center[0],
+      y: intrinsicsExport.center[1]
+    }
+  }
+}
+
+/**
+ * Transform internal extrinsic parameters to export type
+ *
+ * @param extrinsics
+ */
+export function extrinsicsToExport(
+  extrinsics: types.ExtrinsicsType
+): bdd.ExtrinsicsExportType {
+  return {
+    location: [
+      extrinsics.translation.x,
+      extrinsics.translation.y,
+      extrinsics.translation.z
+    ],
+    rotation: [
+      extrinsics.rotation.x,
+      extrinsics.rotation.y,
+      extrinsics.rotation.z
+    ]
+  }
+}
+
+/**
+ * Transform exported extrinsics to internal type
+ *
+ * @param extrinsicsExport
+ */
+export function extrinsicsFromExport(
+  extrinsicsExport: bdd.ExtrinsicsExportType
+): types.ExtrinsicsType {
+  return {
+    rotation: {
+      x: extrinsicsExport.rotation[0],
+      y: extrinsicsExport.rotation[1],
+      z: extrinsicsExport.rotation[2],
+      w: 0.0
+    },
+    translation: {
+      x: extrinsicsExport.location[0],
+      y: extrinsicsExport.location[1],
+      z: extrinsicsExport.location[2]
+    }
   }
 }

--- a/app/src/server/bdd_type_transformers.ts
+++ b/app/src/server/bdd_type_transformers.ts
@@ -168,3 +168,31 @@ export function extrinsicsFromExport(
     }
   }
 }
+
+/**
+ * Transform exported sensors to internal type
+ *
+ * @param sensors
+ */
+export function sensorsFromExport(sensorExportMap: {
+  [id: number]: bdd.SensorExportType
+}): types.SensorMapType {
+  const sensors: types.SensorMapType = {}
+  for (const key of Object.keys(sensorExportMap)) {
+    const sensorExport = sensorExportMap[Number(key)]
+    sensors[Number(key)] = {
+      ...sensorExport,
+      intrinsics:
+        sensorExport.intrinsics === undefined ||
+        sensorExport.intrinsics === null
+          ? undefined
+          : intrinsicsFromExport(sensorExport.intrinsics),
+      extrinsics:
+        sensorExport.extrinsics === undefined ||
+        sensorExport.extrinsics === null
+          ? undefined
+          : extrinsicsFromExport(sensorExport.extrinsics)
+    }
+  }
+  return sensors
+}

--- a/app/src/server/create_project.ts
+++ b/app/src/server/create_project.ts
@@ -40,6 +40,10 @@ import { Storage } from "./storage"
 import * as util from "./util"
 import { mergeNearbyVertices, polyIsComplex } from "../math/polygon2d"
 import Logger from "./logger"
+import {
+  extrinsicsFromExport,
+  intrinsicsFromExport
+} from "./bdd_type_transformers"
 
 /**
  * convert fields to form and validate input
@@ -682,8 +686,12 @@ export async function createTasks(
           maxSensorId,
           "",
           itemExport.dataType,
-          itemExport.intrinsics,
-          itemExport.extrinsics
+          itemExport.intrinsics !== undefined
+            ? intrinsicsFromExport(itemExport.intrinsics)
+            : undefined,
+          itemExport.extrinsics !== undefined
+            ? extrinsicsFromExport(itemExport.extrinsics)
+            : undefined
         )
         itemExport.sensor = maxSensorId
         itemExport.dataType = undefined

--- a/app/src/server/create_project.ts
+++ b/app/src/server/create_project.ts
@@ -19,7 +19,8 @@ import {
   DatasetExport,
   ItemExport,
   ItemGroupExport,
-  LabelExport
+  LabelExport,
+  SensorExportType
 } from "../types/export"
 import { CreationForm, FormFileData, Project } from "../types/project"
 import {
@@ -42,7 +43,8 @@ import { mergeNearbyVertices, polyIsComplex } from "../math/polygon2d"
 import Logger from "./logger"
 import {
   extrinsicsFromExport,
-  intrinsicsFromExport
+  intrinsicsFromExport,
+  sensorsFromExport
 } from "./bdd_type_transformers"
 
 /**
@@ -129,7 +131,7 @@ export async function parseFiles(
     getDefaultCategories(labelType)
   )
 
-  const sensors: Promise<SensorType[]> = readConfig(
+  const sensors: Promise<SensorExportType[]> = readConfig(
     storage,
     _.get(files, FormField.SENSORS),
     []
@@ -157,7 +159,7 @@ export async function parseFiles(
     (
       result: [
         [Array<Partial<ItemExport>>, Array<Partial<ItemGroupExport>>],
-        SensorType[],
+        SensorExportType[],
         Label2DTemplateType[],
         Attribute[],
         Category[]
@@ -371,7 +373,7 @@ export async function createProject(
     }
   })
 
-  const sensors: { [id: number]: SensorType } = {}
+  const sensors: { [id: number]: SensorExportType } = {}
   for (const sensor of formFileData.sensors) {
     sensors[sensor.id] = sensor
   }
@@ -667,7 +669,7 @@ export async function createTasks(
   itemStartNum: number = 0,
   returnTask: boolean = false
 ): Promise<TaskType[]> {
-  const sensors = project.sensors
+  const sensors = sensorsFromExport(project.sensors)
   const { itemType, taskSize, tracking, labelTypes } = project.config
 
   const items = filterInvalidItems(project.items, itemType, sensors)

--- a/app/src/server/create_project.ts
+++ b/app/src/server/create_project.ts
@@ -686,12 +686,12 @@ export async function createTasks(
           maxSensorId,
           "",
           itemExport.dataType,
-          itemExport.intrinsics !== undefined
-            ? intrinsicsFromExport(itemExport.intrinsics)
-            : undefined,
-          itemExport.extrinsics !== undefined
-            ? extrinsicsFromExport(itemExport.extrinsics)
-            : undefined
+          itemExport.intrinsics === undefined || itemExport.intrinsics === null
+            ? undefined
+            : intrinsicsFromExport(itemExport.intrinsics),
+          itemExport.extrinsics === undefined || itemExport.extrinsics === null
+            ? undefined
+            : extrinsicsFromExport(itemExport.extrinsics)
         )
         itemExport.sensor = maxSensorId
         itemExport.dataType = undefined

--- a/app/src/server/create_project.ts
+++ b/app/src/server/create_project.ts
@@ -668,7 +668,7 @@ export async function createTasks(
   returnTask: boolean = false
 ): Promise<TaskType[]> {
   const sensors = project.sensors
-  const { itemType, taskSize, tracking } = project.config
+  const { itemType, taskSize, tracking, labelTypes } = project.config
 
   const items = filterInvalidItems(project.items, itemType, sensors)
 
@@ -774,7 +774,8 @@ export async function createTasks(
         attributeNameMap,
         attributeValueMap,
         categoryNameMap,
-        tracking
+        tracking,
+        labelTypes
       )
 
       if (tracking) {

--- a/app/src/server/export.ts
+++ b/app/src/server/export.ts
@@ -11,6 +11,8 @@ import {
   State
 } from "../types/state"
 import {
+  extrinsicsToExport,
+  intrinsicsToExport,
   transformBox2D,
   transformBox3D,
   transformPlane3D
@@ -79,9 +81,13 @@ export function convertItemToExport(
       labels: [],
       sensor,
       intrinsics:
-        item.intrinsics !== undefined ? item.intrinsics[sensor] : undefined,
+        item.intrinsics !== undefined
+          ? intrinsicsToExport(item.intrinsics[sensor])
+          : undefined,
       extrinsics:
-        item.extrinsics !== undefined ? item.extrinsics[sensor] : undefined
+        item.extrinsics !== undefined
+          ? extrinsicsToExport(item.extrinsics[sensor])
+          : undefined
     }
   }
   // TODO: Clean up the export code for naming and modularity

--- a/app/src/server/import.ts
+++ b/app/src/server/import.ts
@@ -10,7 +10,12 @@ import {
   makePlane,
   makeRect
 } from "../functional/states"
-import { ItemExport, LabelExport } from "../types/export"
+import {
+  ExtrinsicsExportType,
+  IntrinsicsExportType,
+  ItemExport,
+  LabelExport
+} from "../types/export"
 import {
   Attribute,
   ExtrinsicsType,
@@ -23,6 +28,11 @@ import {
   ShapeIdMap,
   ShapeType
 } from "../types/state"
+import {
+  box3dToCube,
+  extrinsicsFromExport,
+  intrinsicsFromExport
+} from "./bdd_type_transformers"
 
 /**
  * Convert the attributes to label to ensure the format consistency
@@ -75,12 +85,14 @@ export function convertItemToImport(
       names[sensorId] = itemExportMap[sensorId].name as string
     }
     if (itemExportMap[sensorId].intrinsics !== undefined) {
-      intrinsics[sensorId] = itemExportMap[sensorId]
-        .intrinsics as IntrinsicsType
+      intrinsics[sensorId] = intrinsicsFromExport(
+        itemExportMap[sensorId].intrinsics as IntrinsicsExportType
+      )
     }
     if (itemExportMap[sensorId].extrinsics !== undefined) {
-      extrinsics[sensorId] = itemExportMap[sensorId]
-        .extrinsics as ExtrinsicsType
+      extrinsics[sensorId] = extrinsicsFromExport(
+        itemExportMap[sensorId].extrinsics as ExtrinsicsExportType
+      )
     }
     let labelsExport = itemExportMap[sensorId].labels
     const itemAttributes = itemExportMap[sensorId].attributes
@@ -255,7 +267,7 @@ function convertLabelToImport(
     )
   } else if (labelExport.box3d !== null && labelExport.box3d !== undefined) {
     labelType = LabelTypeName.BOX_3D
-    shapes = [makeCube(labelExport.box3d)]
+    shapes = [makeCube(box3dToCube(labelExport.box3d))]
   } else if (
     labelExport.plane3d !== null &&
     labelExport.plane3d !== undefined
@@ -281,7 +293,7 @@ function convertLabelToImport(
       type: labelType,
       item,
       shapes: shapeIds,
-      manual: labelExport.manualShape,
+      manual: labelExport.manualShape || false,
       category,
       attributes,
       sensors: [sensorId]

--- a/app/src/server/import.ts
+++ b/app/src/server/import.ts
@@ -84,12 +84,18 @@ export function convertItemToImport(
     if (itemExportMap[sensorId].name !== undefined) {
       names[sensorId] = itemExportMap[sensorId].name as string
     }
-    if (itemExportMap[sensorId].intrinsics !== undefined) {
+    if (
+      itemExportMap[sensorId].intrinsics !== undefined &&
+      itemExportMap[sensorId].intrinsics !== null
+    ) {
       intrinsics[sensorId] = intrinsicsFromExport(
         itemExportMap[sensorId].intrinsics as IntrinsicsExportType
       )
     }
-    if (itemExportMap[sensorId].extrinsics !== undefined) {
+    if (
+      itemExportMap[sensorId].extrinsics !== undefined &&
+      itemExportMap[sensorId].extrinsics !== null
+    ) {
       extrinsics[sensorId] = extrinsicsFromExport(
         itemExportMap[sensorId].extrinsics as ExtrinsicsExportType
       )
@@ -124,7 +130,10 @@ export function convertItemToImport(
         }
 
         let attributes: { [key: number]: number[] } = {}
-        if (labelExport.attributes !== undefined) {
+        if (
+          labelExport.attributes !== undefined &&
+          labelExport.attributes !== null
+        ) {
           attributes = parseExportAttributes(
             labelExport.attributes,
             attributeNameMap,

--- a/app/src/types/export.ts
+++ b/app/src/types/export.ts
@@ -1,8 +1,6 @@
 import {
   Attribute,
   ConfigType,
-  ExtrinsicsType,
-  IntrinsicsType,
   ItemType,
   SensorType,
   TaskStatus,
@@ -30,6 +28,20 @@ export interface DatasetExport {
   config: ConfigExport
 }
 
+export interface IntrinsicsExportType {
+  /** focal length */
+  focal: [number, number]
+  /** focal center */
+  center: [number, number]
+}
+
+export interface ExtrinsicsExportType {
+  /** 3D location reltative to world origin */
+  location: [number, number, number]
+  /** 3D rotation relative to a world origin in axis-angle representation */
+  rotation: [number, number, number]
+}
+
 export interface ItemExport {
   /** project name */
   name: string
@@ -42,9 +54,9 @@ export interface ItemExport {
   /** data type, overrides data source if present */
   dataType?: string
   /** intrinsics, overrides data source if present */
-  intrinsics?: IntrinsicsType
+  intrinsics?: IntrinsicsExportType
   /** extrinsics, overrides data source if present */
-  extrinsics?: ExtrinsicsType
+  extrinsics?: ExtrinsicsExportType
   /** item attributes */
   attributes: { [key: string]: string | string[] }
   /** submitted timestamp */
@@ -80,11 +92,11 @@ export interface Box2DType {
 
 export interface Box3DType {
   /** Center of the cube */
-  center: Vector3Type
+  location: [number, number, number]
   /** size */
-  size: Vector3Type
+  dimension: [number, number, number]
   /** orientation */
-  orientation: Vector3Type
+  orientation: [number, number, number]
 }
 
 export interface Plane3DType {

--- a/app/src/types/export.ts
+++ b/app/src/types/export.ts
@@ -2,7 +2,6 @@ import {
   Attribute,
   ConfigType,
   ItemType,
-  SensorType,
   TaskStatus,
   TrackType,
   Vector3Type
@@ -26,6 +25,19 @@ export interface DatasetExport {
   frameGroups?: ItemGroupExport[]
   /** shared fields for frames */
   config: ConfigExport
+}
+
+export interface SensorExportType {
+  /** id */
+  id: number
+  /** name */
+  name: string
+  /** data type */
+  type: string
+  /** intrinsics */
+  intrinsics?: IntrinsicsExportType
+  /** extrinsics */
+  extrinsics?: ExtrinsicsExportType
 }
 
 export interface IntrinsicsExportType {
@@ -148,7 +160,7 @@ export interface ConfigExport {
   /** categories */
   categories: string[]
   /** sensors */
-  sensors?: SensorType[]
+  sensors?: SensorExportType[]
 }
 
 export interface ImageSizeType {

--- a/app/src/types/project.ts
+++ b/app/src/types/project.ts
@@ -1,11 +1,5 @@
-import { ItemExport, ItemGroupExport } from "./export"
-import {
-  Attribute,
-  Category,
-  ConfigType,
-  Label2DTemplateType,
-  SensorType
-} from "./state"
+import { ItemExport, ItemGroupExport, SensorExportType } from "./export"
+import { Attribute, Category, ConfigType, Label2DTemplateType } from "./state"
 
 /**
  * Stores specifications of project
@@ -18,7 +12,7 @@ export interface Project {
   /** frontend config */
   config: ConfigType
   /** map between data source id and data sources */
-  sensors: { [id: number]: SensorType }
+  sensors: { [id: number]: SensorExportType }
 }
 
 /**
@@ -46,7 +40,7 @@ export interface FormFileData {
   /** categories parsed from form file */
   categories: Category[]
   /** sensors */
-  sensors: SensorType[]
+  sensors: SensorExportType[]
   /** custom label template */
   templates: Label2DTemplateType[]
   /** attributes parsed from form file */

--- a/app/test/server/create_project.test.ts
+++ b/app/test/server/create_project.test.ts
@@ -15,8 +15,10 @@ import {
   sampleFormImage,
   sampleFormVideo,
   sampleProjectAutolabel,
+  sampleProjectAutolabel3dBox,
   sampleProjectAutolabelPolygon,
   sampleProjectImage,
+  sampleProjectSensors,
   sampleProjectVideo,
   sampleTasksImage,
   // SampleTasksVideo,
@@ -24,6 +26,7 @@ import {
 } from "../test_states/test_creation_objects"
 import {
   sampleStateExportImage,
+  sampleStateExportImage3dBox,
   sampleStateExportImagePolygon
 } from "../test_states/test_export_objects"
 
@@ -121,6 +124,36 @@ describe("create with auto labels", () => {
       const exportedItems = convertStateToExport(state as State)
       expect(exportedItems).toEqual(sampleStateExportImagePolygon)
     })
+  })
+
+  test("import then export for 3d bounding box", async () => {
+    return await createTasks(
+      sampleProjectAutolabel3dBox,
+      undefined,
+      0,
+      0,
+      true
+    ).then((tasks) => {
+      // Only 1 task should be created
+      const state: Partial<State> = {
+        task: tasks[0]
+      }
+      const exportedItems = convertStateToExport(state as State)
+      expect(exportedItems).toEqual(sampleStateExportImage3dBox)
+    })
+  })
+
+  test("import then export for camera sensor", async () => {
+    return await createTasks(sampleProjectSensors, undefined, 0, 0, true).then(
+      (tasks) => {
+        // Only 1 task should be created
+        const state: Partial<State> = {
+          task: tasks[0]
+        }
+        const exportedItems = convertStateToExport(state as State)
+        expect(exportedItems).toEqual(sampleStateExportImage3dBox)
+      }
+    )
   })
 })
 

--- a/app/test/server/export.test.ts
+++ b/app/test/server/export.test.ts
@@ -13,13 +13,16 @@ import {
   sampleItemExportImage,
   sampleItemExportImagePolygon,
   sampleStateExportImage,
-  sampleStateExportImagePolygon
+  sampleStateExportImagePolygon,
+  sampleItemExportImage3dBox,
+  sampleStateExportImage3dBox
 } from "../test_states/test_export_objects"
 
 const sampleStateFile = "./app/test/test_states/sample_state.json"
 const samplePolygonStateFile =
   "./app/test/test_states/sample_state_polygon.json"
 const sampleTagStateFile = "./app/test/test_states/sample_state_tag.json"
+const sample3dBoxStateFile = "./app/test/test_states/sample_state_3d_box.json"
 
 describe("test export functionality across multiple labeling types", () => {
   test("unit test for polygon export", () => {
@@ -82,6 +85,21 @@ describe("test export functionality for segmentation", () => {
 describe("test export functionality for tracking", () => {
   test("single item conversion", () => {})
   test("full state export including empty items", () => {})
+})
+
+describe("test export functionality for 3d bounding box", () => {
+  test("single item conversion", () => {
+    const state = readSampleState(sample3dBoxStateFile)
+    const config = state.task.config
+    const item = state.task.items[0]
+    const itemExport = convertItemToExport(config, item)[0]
+    expect(itemExport).toEqual(sampleItemExportImage3dBox)
+  })
+  test("full state export including empty items", () => {
+    const state = readSampleState(sample3dBoxStateFile)
+    const exportedState = convertStateToExport(state)
+    expect(exportedState).toEqual(sampleStateExportImage3dBox)
+  })
 })
 
 /**

--- a/app/test/test_states/sample_state_3d_box.json
+++ b/app/test/test_states/sample_state_3d_box.json
@@ -1,0 +1,468 @@
+{
+    "task": {
+        "config": {
+            "projectName": "image3dBox",
+            "itemType": "image",
+            "labelTypes": [
+                "box3d"
+            ],
+            "label2DTemplates": {},
+            "taskSize": 1,
+            "handlerUrl": "label",
+            "pageTitle": "3D Bounding Box",
+            "instructionPage": "",
+            "bundleFile": "image.js",
+            "categories": [
+                "pedestrian",
+                "rider",
+                "other person",
+                "car",
+                "bus",
+                "truck",
+                "train",
+                "trailer",
+                "other vehicle",
+                "motorcycle",
+                "bicycle",
+                "traffic sign",
+                "traffic light"
+            ],
+            "treeCategories": [
+                {
+                    "name": "pedestrian"
+                },
+                {
+                    "name": "rider"
+                },
+                {
+                    "name": "other person"
+                },
+                {
+                    "name": "car"
+                },
+                {
+                    "name": "bus"
+                },
+                {
+                    "name": "truck"
+                },
+                {
+                    "name": "train"
+                },
+                {
+                    "name": "trailer"
+                },
+                {
+                    "name": "other vehicle"
+                },
+                {
+                    "name": "motorcycle"
+                },
+                {
+                    "name": "bicycle"
+                },
+                {
+                    "name": "traffic sign"
+                },
+                {
+                    "name": "traffic light"
+                }
+            ],
+            "attributes": [],
+            "taskId": "000000",
+            "tracking": false,
+            "policyTypes": [],
+            "demoMode": false,
+            "autosave": true,
+            "bots": false
+        },
+        "status": {
+            "maxOrder": 7
+        },
+        "items": [
+            {
+                "id": "0",
+                "index": 0,
+                "videoName": "",
+                "urls": {
+                    "-1": "http://localhost:8686/items/kitti/tracking/training/image_02/0001/000000.png"
+                },
+                "labels": {
+                    "0": {
+                        "id": "0",
+                        "item": 0,
+                        "sensors": [
+                            -1
+                        ],
+                        "type": "box3d",
+                        "category": [
+                            3
+                        ],
+                        "attributes": {},
+                        "parent": "",
+                        "children": [],
+                        "shapes": [
+                            "q2IA9xVDZqBsPVfm"
+                        ],
+                        "track": "",
+                        "order": 0,
+                        "manual": false,
+                        "changed": false
+                    },
+                    "1": {
+                        "id": "1",
+                        "item": 0,
+                        "sensors": [
+                            -1
+                        ],
+                        "type": "box3d",
+                        "category": [
+                            3
+                        ],
+                        "attributes": {},
+                        "parent": "",
+                        "children": [],
+                        "shapes": [
+                            "AGX396iafcf9k4Mm"
+                        ],
+                        "track": "",
+                        "order": 0,
+                        "manual": false,
+                        "changed": false
+                    },
+                    "2": {
+                        "id": "2",
+                        "item": 0,
+                        "sensors": [
+                            -1
+                        ],
+                        "type": "box3d",
+                        "category": [
+                            3
+                        ],
+                        "attributes": {},
+                        "parent": "",
+                        "children": [],
+                        "shapes": [
+                            "RjDdt1AXrAhLL4fR"
+                        ],
+                        "track": "",
+                        "order": 0,
+                        "manual": false,
+                        "changed": false
+                    },
+                    "3": {
+                        "id": "3",
+                        "item": 0,
+                        "sensors": [
+                            -1
+                        ],
+                        "type": "box3d",
+                        "category": [
+                            3
+                        ],
+                        "attributes": {},
+                        "parent": "",
+                        "children": [],
+                        "shapes": [
+                            "PnZA1pGnrUleiTkb"
+                        ],
+                        "track": "",
+                        "order": 0,
+                        "manual": false,
+                        "changed": false
+                    },
+                    "4": {
+                        "id": "4",
+                        "item": 0,
+                        "sensors": [
+                            -1
+                        ],
+                        "type": "box3d",
+                        "category": [
+                            3
+                        ],
+                        "attributes": {},
+                        "parent": "",
+                        "children": [],
+                        "shapes": [
+                            "iyHysmk5NM66bgwP"
+                        ],
+                        "track": "",
+                        "order": 0,
+                        "manual": false,
+                        "changed": false
+                    },
+                    "5": {
+                        "id": "5",
+                        "item": 0,
+                        "sensors": [
+                            -1
+                        ],
+                        "type": "box3d",
+                        "category": [
+                            3
+                        ],
+                        "attributes": {},
+                        "parent": "",
+                        "children": [],
+                        "shapes": [
+                            "i30Jhe5mW781XR6z"
+                        ],
+                        "track": "",
+                        "order": 0,
+                        "manual": false,
+                        "changed": false
+                    },
+                    "6": {
+                        "id": "6",
+                        "item": 0,
+                        "sensors": [
+                            -1
+                        ],
+                        "type": "box3d",
+                        "category": [
+                            3
+                        ],
+                        "attributes": {},
+                        "parent": "",
+                        "children": [],
+                        "shapes": [
+                            "7Q0ouEB0S2Osa9Ka"
+                        ],
+                        "track": "",
+                        "order": 0,
+                        "manual": false,
+                        "changed": false
+                    }
+                },
+                "shapes": {
+                    "q2IA9xVDZqBsPVfm": {
+                        "center": {
+                            "x": 2.921483,
+                            "y": 0.755883,
+                            "z": 6.348542
+                        },
+                        "size": {
+                            "x": 1.50992,
+                            "y": 1.85,
+                            "z": 4.930564
+                        },
+                        "orientation": {
+                            "x": 0,
+                            "y": 3.2679489647691184e-7,
+                            "z": 0
+                        },
+                        "anchorIndex": 0,
+                        "label": [
+                            "0"
+                        ],
+                        "shapeType": "cube",
+                        "id": "q2IA9xVDZqBsPVfm"
+                    },
+                    "AGX396iafcf9k4Mm": {
+                        "center": {
+                            "x": 2.994469,
+                            "y": 0.8304805,
+                            "z": 13.169745
+                        },
+                        "size": {
+                            "x": 1.404795,
+                            "y": 1.612032,
+                            "z": 3.772344
+                        },
+                        "orientation": {
+                            "x": 0,
+                            "y": 3.2679489647691184e-7,
+                            "z": 0
+                        },
+                        "anchorIndex": 0,
+                        "label": [
+                            "1"
+                        ],
+                        "shapeType": "cube",
+                        "id": "AGX396iafcf9k4Mm"
+                    },
+                    "RjDdt1AXrAhLL4fR": {
+                        "center": {
+                            "x": 2.908125,
+                            "y": 0.8767944999999999,
+                            "z": 19.299001
+                        },
+                        "size": {
+                            "x": 1.413269,
+                            "y": 1.567278,
+                            "z": 3.158158
+                        },
+                        "orientation": {
+                            "x": 0,
+                            "y": 0.05897932679489659,
+                            "z": 0
+                        },
+                        "anchorIndex": 0,
+                        "label": [
+                            "2"
+                        ],
+                        "shapeType": "cube",
+                        "id": "RjDdt1AXrAhLL4fR"
+                    },
+                    "PnZA1pGnrUleiTkb": {
+                        "center": {
+                            "x": -6.037999,
+                            "y": 1.4392370000000003,
+                            "z": 23.712843
+                        },
+                        "size": {
+                            "x": 1.527328,
+                            "y": 1.555003,
+                            "z": 3.57675
+                        },
+                        "orientation": {
+                            "x": 0,
+                            "y": 3.1579983267948966,
+                            "z": 0
+                        },
+                        "anchorIndex": 0,
+                        "label": [
+                            "3"
+                        ],
+                        "shapeType": "cube",
+                        "id": "PnZA1pGnrUleiTkb"
+                    },
+                    "iyHysmk5NM66bgwP": {
+                        "center": {
+                            "x": -6.310451,
+                            "y": 1.7865565,
+                            "z": 46.486705
+                        },
+                        "size": {
+                            "x": 1.417371,
+                            "y": 1.540476,
+                            "z": 3.504344
+                        },
+                        "orientation": {
+                            "x": 0,
+                            "y": 3.1323123267948967,
+                            "z": 0
+                        },
+                        "anchorIndex": 0,
+                        "label": [
+                            "4"
+                        ],
+                        "shapeType": "cube",
+                        "id": "iyHysmk5NM66bgwP"
+                    },
+                    "i30Jhe5mW781XR6z": {
+                        "center": {
+                            "x": 2.822686,
+                            "y": 1.2086425,
+                            "z": 50.003616
+                        },
+                        "size": {
+                            "x": 1.512623,
+                            "y": 1.746309,
+                            "z": 3.775171
+                        },
+                        "orientation": {
+                            "x": 0,
+                            "y": -0.0013926732051035007,
+                            "z": 0
+                        },
+                        "anchorIndex": 0,
+                        "label": [
+                            "5"
+                        ],
+                        "shapeType": "cube",
+                        "id": "i30Jhe5mW781XR6z"
+                    },
+                    "7Q0ouEB0S2Osa9Ka": {
+                        "center": {
+                            "x": -6.285505,
+                            "y": 1.7774785,
+                            "z": 52.066669
+                        },
+                        "size": {
+                            "x": 1.360295,
+                            "y": 1.513462,
+                            "z": 4.017021
+                        },
+                        "orientation": {
+                            "x": 0,
+                            "y": 3.1543543267948966,
+                            "z": 0
+                        },
+                        "anchorIndex": 0,
+                        "label": [
+                            "6"
+                        ],
+                        "shapeType": "cube",
+                        "id": "7Q0ouEB0S2Osa9Ka"
+                    }
+                },
+                "timestamp": 0,
+                "names": {},
+                "intrinsics": {
+                    "-1": {
+                        "focalLength": {
+                            "x": 721.5377197265625,
+                            "y": 721.5377197265625
+                        },
+                        "focalCenter": {
+                            "x": 609.559326171875,
+                            "y": 172.85400390625
+                        }
+                    }
+                },
+                "extrinsics": {
+                    "-1": {
+                        "rotation": {
+                            "x": -1.5723664220969806,
+                            "y": 0.07224191126404556,
+                            "z": -1.8406363281435645,
+                            "w": 0
+                        },
+                        "translation": {
+                            "x": -0.5327253937721252,
+                            "y": 0.0,
+                            "z": 0.0
+                        }
+                    }
+                }
+            }
+        ],
+        "tracks": {},
+        "sensors": {
+            "-1": {
+                "id": -1,
+                "name": "image2",
+                "type": "image",
+                "intrinsics": {
+                    "focalLength": {
+                        "x": 721.5377197265625,
+                        "y": 721.5377197265625
+                    },
+                    "focalCenter": {
+                        "x": 609.559326171875,
+                        "y": 172.85400390625
+                    }
+                },
+                "extrinsics": {
+                    "rotation": {
+                        "x": -1.5723664220969806,
+                        "y": 0.07224191126404556,
+                        "z": -1.8406363281435645,
+                        "w": 0
+                    },
+                    "translation": {
+                        "x": -0.5327253937721252,
+                        "y": 0.0,
+                        "z": 0.0
+                    }
+                }
+            }
+        },
+        "progress": {
+            "submissions": []
+        }
+    }
+}

--- a/app/test/test_states/test_creation_objects.ts
+++ b/app/test/test_states/test_creation_objects.ts
@@ -13,6 +13,7 @@ import { CreationForm, FormFileData, Project } from "../../src/types/project"
 import { Attribute, Category, TaskType } from "../../src/types/state"
 import {
   sampleStateExportImage,
+  sampleStateExportImage3dBox,
   sampleStateExportImagePolygon
 } from "./test_export_objects"
 
@@ -341,6 +342,74 @@ export const sampleProjectAutolabelPolygon: Project = {
   sensors: {}
 }
 
+export const sampleProjectAutolabel3dBox: Project = {
+  items: sampleStateExportImage3dBox,
+  config: {
+    projectName: sampleProjectName,
+    itemType: ItemTypeName.IMAGE,
+    labelTypes: [LabelTypeName.BOX_3D],
+    label2DTemplates: {},
+    policyTypes: [],
+    taskSize: sampleTaskSize,
+    tracking: false,
+    handlerUrl: HandlerUrl.LABEL,
+    pageTitle: sampleTitle,
+    instructionPage: sampleInstructions,
+    bundleFile: BundleFile.V2,
+    categories: sampleCategories,
+    treeCategories: sampleTreeCategories,
+    attributes: sampleAttributes as Attribute[],
+    taskId: "",
+    demoMode: false,
+    autosave: true,
+    bots: false
+  },
+  sensors: {}
+}
+
+export const sampleProjectSensors: Project = {
+  items: sampleStateExportImage3dBox,
+  config: {
+    projectName: sampleProjectName,
+    itemType: ItemTypeName.IMAGE,
+    labelTypes: [LabelTypeName.BOX_3D],
+    label2DTemplates: {},
+    policyTypes: [],
+    taskSize: sampleTaskSize,
+    tracking: false,
+    handlerUrl: HandlerUrl.LABEL,
+    pageTitle: sampleTitle,
+    instructionPage: sampleInstructions,
+    bundleFile: BundleFile.V2,
+    categories: sampleCategories,
+    treeCategories: sampleTreeCategories,
+    attributes: sampleAttributes as Attribute[],
+    taskId: "",
+    demoMode: false,
+    autosave: true,
+    bots: false
+  },
+  sensors: {
+    "-1": {
+      id: -1,
+      name: "image2",
+      type: "image",
+      intrinsics: {
+        focal: [721.5377197265625, 721.5377197265625],
+        center: [609.559326171875, 172.85400390625]
+      },
+
+      extrinsics: {
+        location: [-0.5327253937721252, 0.0, 0.0],
+        rotation: [
+          -1.5723664220969806,
+          0.07224191126404556,
+          -1.8406363281435645
+        ]
+      }
+    }
+  }
+}
 export const sampleTasksImage: TaskType[] = [
   {
     config: {

--- a/app/test/test_states/test_export_objects.ts
+++ b/app/test/test_states/test_export_objects.ts
@@ -369,3 +369,229 @@ export const sampleItemExportImageTagging: ItemExport = {
   sensor: -1,
   labels: []
 }
+
+export const sampleItemExportImage3dBox: ItemExport = {
+  name:
+    "http://localhost:8686/items/kitti/tracking/training/image_02/0001/000000.png",
+  url:
+    "http://localhost:8686/items/kitti/tracking/training/image_02/0001/000000.png",
+  videoName: "",
+  timestamp: 0,
+  attributes: {},
+  labels: [
+    {
+      id: "0",
+      category: "car",
+      attributes: {},
+      manualShape: false,
+      box2d: null,
+      poly2d: null,
+      box3d: {
+        location: [2.921483, 0.755883, 6.348542],
+        dimension: [1.50992, 1.85, 4.930564],
+        orientation: [0, 3.2679489647691184e-7, 0]
+      }
+    },
+    {
+      id: "1",
+      category: "car",
+      attributes: {},
+      manualShape: false,
+      box2d: null,
+      poly2d: null,
+      box3d: {
+        location: [2.994469, 0.8304805, 13.169745],
+        dimension: [1.404795, 1.612032, 3.772344],
+        orientation: [0, 3.2679489647691184e-7, 0]
+      }
+    },
+    {
+      id: "2",
+      category: "car",
+      attributes: {},
+      manualShape: false,
+      box2d: null,
+      poly2d: null,
+      box3d: {
+        location: [2.908125, 0.8767944999999999, 19.299001],
+        dimension: [1.413269, 1.567278, 3.158158],
+        orientation: [0, 0.05897932679489659, 0]
+      }
+    },
+    {
+      id: "3",
+      category: "car",
+      attributes: {},
+      manualShape: false,
+      box2d: null,
+      poly2d: null,
+      box3d: {
+        location: [-6.037999, 1.4392370000000003, 23.712843],
+        dimension: [1.527328, 1.555003, 3.57675],
+        orientation: [0, 3.1579983267948966, 0]
+      }
+    },
+    {
+      id: "4",
+      category: "car",
+      attributes: {},
+      manualShape: false,
+      box2d: null,
+      poly2d: null,
+      box3d: {
+        location: [-6.310451, 1.7865565, 46.486705],
+        dimension: [1.417371, 1.540476, 3.504344],
+        orientation: [0, 3.1323123267948967, 0]
+      }
+    },
+    {
+      id: "5",
+      category: "car",
+      attributes: {},
+      manualShape: false,
+      box2d: null,
+      poly2d: null,
+      box3d: {
+        location: [2.822686, 1.2086425, 50.003616],
+        dimension: [1.512623, 1.746309, 3.775171],
+        orientation: [0, -0.0013926732051035007, 0]
+      }
+    },
+    {
+      id: "6",
+      category: "car",
+      attributes: {},
+      manualShape: false,
+      box2d: null,
+      poly2d: null,
+      box3d: {
+        location: [-6.285505, 1.7774785, 52.066669],
+        dimension: [1.360295, 1.513462, 4.017021],
+        orientation: [0, 3.1543543267948966, 0]
+      }
+    }
+  ],
+  sensor: -1,
+  intrinsics: {
+    focal: [721.5377197265625, 721.5377197265625],
+    center: [609.559326171875, 172.85400390625]
+  },
+  extrinsics: {
+    location: [-0.5327253937721252, 0.0, 0.0],
+    rotation: [-1.5723664220969806, 0.07224191126404556, -1.8406363281435645]
+  }
+}
+
+export const sampleStateExportImage3dBox: ItemExport[] = [
+  {
+    name:
+      "http://localhost:8686/items/kitti/tracking/training/image_02/0001/000000.png",
+    url:
+      "http://localhost:8686/items/kitti/tracking/training/image_02/0001/000000.png",
+    videoName: "",
+    timestamp: 0,
+    attributes: {},
+    labels: [
+      {
+        id: "0",
+        category: "car",
+        attributes: {},
+        manualShape: false,
+        box2d: null,
+        poly2d: null,
+        box3d: {
+          location: [2.921483, 0.755883, 6.348542],
+          dimension: [1.50992, 1.85, 4.930564],
+          orientation: [0, 3.2679489647691184e-7, 0]
+        }
+      },
+      {
+        id: "1",
+        category: "car",
+        attributes: {},
+        manualShape: false,
+        box2d: null,
+        poly2d: null,
+        box3d: {
+          location: [2.994469, 0.8304805, 13.169745],
+          dimension: [1.404795, 1.612032, 3.772344],
+          orientation: [0, 3.2679489647691184e-7, 0]
+        }
+      },
+      {
+        id: "2",
+        category: "car",
+        attributes: {},
+        manualShape: false,
+        box2d: null,
+        poly2d: null,
+        box3d: {
+          location: [2.908125, 0.8767944999999999, 19.299001],
+          dimension: [1.413269, 1.567278, 3.158158],
+          orientation: [0, 0.05897932679489659, 0]
+        }
+      },
+      {
+        id: "3",
+        category: "car",
+        attributes: {},
+        manualShape: false,
+        box2d: null,
+        poly2d: null,
+        box3d: {
+          location: [-6.037999, 1.4392370000000003, 23.712843],
+          dimension: [1.527328, 1.555003, 3.57675],
+          orientation: [0, 3.1579983267948966, 0]
+        }
+      },
+      {
+        id: "4",
+        category: "car",
+        attributes: {},
+        manualShape: false,
+        box2d: null,
+        poly2d: null,
+        box3d: {
+          location: [-6.310451, 1.7865565, 46.486705],
+          dimension: [1.417371, 1.540476, 3.504344],
+          orientation: [0, 3.1323123267948967, 0]
+        }
+      },
+      {
+        id: "5",
+        category: "car",
+        attributes: {},
+        manualShape: false,
+        box2d: null,
+        poly2d: null,
+        box3d: {
+          location: [2.822686, 1.2086425, 50.003616],
+          dimension: [1.512623, 1.746309, 3.775171],
+          orientation: [0, -0.0013926732051035007, 0]
+        }
+      },
+      {
+        id: "6",
+        category: "car",
+        attributes: {},
+        manualShape: false,
+        box2d: null,
+        poly2d: null,
+        box3d: {
+          location: [-6.285505, 1.7774785, 52.066669],
+          dimension: [1.360295, 1.513462, 4.017021],
+          orientation: [0, 3.1543543267948966, 0]
+        }
+      }
+    ],
+    sensor: -1,
+    intrinsics: {
+      focal: [721.5377197265625, 721.5377197265625],
+      center: [609.559326171875, 172.85400390625]
+    },
+    extrinsics: {
+      location: [-0.5327253937721252, 0.0, 0.0],
+      rotation: [-1.5723664220969806, 0.07224191126404556, -1.8406363281435645]
+    }
+  }
+]


### PR DESCRIPTION
## Changes

- Update export format of 3d bounding boxes and camera parameters to match python library (and documentation).
- Import labels based on project label types. This fixes the bug where box2d labels override box3d labels during import even in a project set up for 3d bounding box labeling.

## Notes

- This will break backwards compatibility. Existing exports in the old format will no longer import correctly.