### PR TITLE
KITTI velodyne dataset example

### DIFF
--- a/doc/src/format.rst
+++ b/doc/src/format.rst
@@ -45,7 +45,7 @@ Each item in the ``frame`` field is an image with several fields.
 to each label in images. Fields of item are given below.
 
 .. code-block:: yaml
-    
+
     - name: string (must be unique over the whole dataset!)
     - url: string (relative path or URL to data file)
     - videoName: string (optional)
@@ -77,7 +77,7 @@ to each label in images. Fields of item are given below.
             - y2: float
         - box3d:
             - alpha:
-            - orientation: 
+            - orientation:
             - location: ()
             - dimension: (3D point, height, width, length)
         - poly2d:
@@ -121,10 +121,10 @@ More details about the fields
         * location: 3D center of the box, stored as 3D point in camera coordinates, meaning the axes (x,y,z) point right, down, and forward.
         * orientation: 3D orientation of the bounding box, stored as axis angles in the same coordinate frame as the location.
         * dimension: 3D box size, with length in x direction, height in y direction and width in z direction
-    
+
     * poly2d
 
-        * types: Each character corresponds to the type of the vertex with the 
+        * types: Each character corresponds to the type of the vertex with the
           same index in vertices. ‘L’ for vertex and ‘C’ for control point of a
           bezier curve.
         * closed: true for polygon and otherwise for path
@@ -154,3 +154,17 @@ This data structure inherits from ``frame``, s.t. each  ``frameGroup`` has all o
 
     - [inherits all attributes from frame]
     - frames: [ ]str (list of frame names in the group)
+
+KITTI Format
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The KITTI Velodyne dataset contains a pointcloud file (``.bin``) and four corresponding image files (``.png``).
+Currently, Scalabel only supports ``.ply`` files for pointclouds. Please refer to
+`this script
+<https://gist.github.com/HTLife/e8f1c4ff1737710e34258ef965b48344>`_ for conversion purposes.
+
+The data structure is similar to that used by ``frameGroup`` above, where the frame names consist of the pointcloud and the four corresponding images.
+
+You can have a quick try by submitting the relevant files in
+`examples/kitti
+<https://github.com/scalabel/scalabel/blob/master/examples/kitti>`_
+and choose Point Cloud  in ``Item Type`` and 3D Bounding Box in ``Label Type``.

--- a/examples/kitti/kitti_categories.yml
+++ b/examples/kitti/kitti_categories.yml
@@ -1,0 +1,67 @@
+- name: void
+  subcategories:
+    - name: unlabeled
+    - name: dynamic
+    - name: ego vehicle
+    - name: ground
+    - name: static
+
+- name: flat
+  subcategories:
+    - name: parking
+    - name: rail track
+    - name: road
+    - name: sidewalk
+
+- name: construction
+  subcategories:
+    - name: bridge
+    - name: building
+    - name: bus stop
+    - name: fence
+    - name: garage
+    - name: guard rail
+    - name: tunnel
+    - name: wall
+
+- name: object
+  subcategories:
+    - name: banner
+    - name: billboard
+    - name: fire hydrant
+    - name: lane divider
+    - name: mail box
+    - name: parking sign
+    - name: pole
+    - name: street light
+    - name: traffic cone
+    - name: traffic device
+    - name: traffic light
+    - name: traffic sign
+    - name: traffic sign frame
+    - name: trash can
+
+- name: nature
+  subcategories:
+    - name: terrain
+    - name: vegetation
+
+- name: sky
+  subcategories:
+    - name: sky
+
+- name: human
+  subcategories:
+    - name: person
+    - name: rider
+
+- name: vehicle
+  subcategories:
+    - name: bicycle
+    - name: bus
+    - name: car
+    - name: caravan
+    - name: motorcycle
+    - name: trailer
+    - name: train
+    - name: truck

--- a/examples/kitti/kitti_list.json
+++ b/examples/kitti/kitti_list.json
@@ -1,0 +1,1238 @@
+{
+  "frames": [
+    {
+      "name": "0000000000",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000000.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000001",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000001.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000002",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000002.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000003",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000003.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000004",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000004.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000005",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000005.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000006",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000006.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000007",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000007.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000008",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000008.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000009",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000009.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000010",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000010.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000011",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000011.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000012",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000012.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000013",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000013.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000014",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000014.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000015",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000015.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000016",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000016.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000017",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000017.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000018",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000018.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000019",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000019.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000020",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000020.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "0000000021",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/ply/0000000021.ply",
+      "videoName": "test"
+    },
+    {
+      "name": "image_00/0000000000",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000000.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 0,
+      "frameIndex": 0
+    },
+    {
+      "name": "image_00/0000000001",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000001.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 1,
+      "frameIndex": 1
+    },
+    {
+      "name": "image_00/0000000002",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000002.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 2,
+      "frameIndex": 2
+    },
+    {
+      "name": "image_00/0000000003",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000003.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 3,
+      "frameIndex": 3
+    },
+    {
+      "name": "image_00/0000000004",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000004.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 4,
+      "frameIndex": 4
+    },
+    {
+      "name": "image_00/0000000005",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000005.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 5,
+      "frameIndex": 5
+    },
+    {
+      "name": "image_00/0000000006",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000006.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 6,
+      "frameIndex": 6
+    },
+    {
+      "name": "image_00/0000000007",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000007.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 7,
+      "frameIndex": 7
+    },
+    {
+      "name": "image_00/0000000008",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000008.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 8,
+      "frameIndex": 8
+    },
+    {
+      "name": "image_00/0000000009",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000009.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 9,
+      "frameIndex": 9
+    },
+    {
+      "name": "image_00/0000000010",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000010.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 10,
+      "frameIndex": 10
+    },
+    {
+      "name": "image_00/0000000011",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000011.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 11,
+      "frameIndex": 11
+    },
+    {
+      "name": "image_00/0000000012",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000012.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 12,
+      "frameIndex": 12
+    },
+    {
+      "name": "image_00/0000000013",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000013.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 13,
+      "frameIndex": 13
+    },
+    {
+      "name": "image_00/0000000014",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000014.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 14,
+      "frameIndex": 14
+    },
+    {
+      "name": "image_00/0000000015",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000015.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 15,
+      "frameIndex": 15
+    },
+    {
+      "name": "image_00/0000000016",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000016.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 16,
+      "frameIndex": 16
+    },
+    {
+      "name": "image_00/0000000017",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000017.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 17,
+      "frameIndex": 17
+    },
+    {
+      "name": "image_00/0000000018",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000018.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 18,
+      "frameIndex": 18
+    },
+    {
+      "name": "image_00/0000000019",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000019.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 19,
+      "frameIndex": 19
+    },
+    {
+      "name": "image_00/0000000020",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000020.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 20,
+      "frameIndex": 20
+    },
+    {
+      "name": "image_00/0000000021",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_00/0000000021.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 21,
+      "frameIndex": 21
+    },
+    {
+      "name": "image_01/0000000000",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000000.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 0,
+      "frameIndex": 0
+    },
+    {
+      "name": "image_01/0000000001",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000001.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 1,
+      "frameIndex": 1
+    },
+    {
+      "name": "image_01/0000000002",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000002.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 2,
+      "frameIndex": 2
+    },
+    {
+      "name": "image_01/0000000003",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000003.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 3,
+      "frameIndex": 3
+    },
+    {
+      "name": "image_01/0000000004",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000004.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 4,
+      "frameIndex": 4
+    },
+    {
+      "name": "image_01/0000000005",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000005.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 5,
+      "frameIndex": 5
+    },
+    {
+      "name": "image_01/0000000006",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000006.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 6,
+      "frameIndex": 6
+    },
+    {
+      "name": "image_01/0000000007",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000007.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 7,
+      "frameIndex": 7
+    },
+    {
+      "name": "image_01/0000000008",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000008.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 8,
+      "frameIndex": 8
+    },
+    {
+      "name": "image_01/0000000009",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000009.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 9,
+      "frameIndex": 9
+    },
+    {
+      "name": "image_01/0000000010",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000010.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 10,
+      "frameIndex": 10
+    },
+    {
+      "name": "image_01/0000000011",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000011.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 11,
+      "frameIndex": 11
+    },
+    {
+      "name": "image_01/0000000012",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000012.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 12,
+      "frameIndex": 12
+    },
+    {
+      "name": "image_01/0000000013",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000013.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 13,
+      "frameIndex": 13
+    },
+    {
+      "name": "image_01/0000000014",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000014.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 14,
+      "frameIndex": 14
+    },
+    {
+      "name": "image_01/0000000015",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000015.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 15,
+      "frameIndex": 15
+    },
+    {
+      "name": "image_01/0000000016",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000016.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 16,
+      "frameIndex": 16
+    },
+    {
+      "name": "image_01/0000000017",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000017.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 17,
+      "frameIndex": 17
+    },
+    {
+      "name": "image_01/0000000018",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000018.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 18,
+      "frameIndex": 18
+    },
+    {
+      "name": "image_01/0000000019",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000019.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 19,
+      "frameIndex": 19
+    },
+    {
+      "name": "image_01/0000000020",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000020.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 20,
+      "frameIndex": 20
+    },
+    {
+      "name": "image_01/0000000021",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_01/0000000021.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 21,
+      "frameIndex": 21
+    },
+    {
+      "name": "image_02/0000000000",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000000.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 0,
+      "frameIndex": 0
+    },
+    {
+      "name": "image_02/0000000001",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000001.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 1,
+      "frameIndex": 1
+    },
+    {
+      "name": "image_02/0000000002",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000002.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 2,
+      "frameIndex": 2
+    },
+    {
+      "name": "image_02/0000000003",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000003.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 3,
+      "frameIndex": 3
+    },
+    {
+      "name": "image_02/0000000004",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000004.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 4,
+      "frameIndex": 4
+    },
+    {
+      "name": "image_02/0000000005",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000005.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 5,
+      "frameIndex": 5
+    },
+    {
+      "name": "image_02/0000000006",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000006.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 6,
+      "frameIndex": 6
+    },
+    {
+      "name": "image_02/0000000007",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000007.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 7,
+      "frameIndex": 7
+    },
+    {
+      "name": "image_02/0000000008",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000008.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 8,
+      "frameIndex": 8
+    },
+    {
+      "name": "image_02/0000000009",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000009.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 9,
+      "frameIndex": 9
+    },
+    {
+      "name": "image_02/0000000010",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000010.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 10,
+      "frameIndex": 10
+    },
+    {
+      "name": "image_02/0000000011",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000011.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 11,
+      "frameIndex": 11
+    },
+    {
+      "name": "image_02/0000000012",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000012.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 12,
+      "frameIndex": 12
+    },
+    {
+      "name": "image_02/0000000013",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000013.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 13,
+      "frameIndex": 13
+    },
+    {
+      "name": "image_02/0000000014",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000014.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 14,
+      "frameIndex": 14
+    },
+    {
+      "name": "image_02/0000000015",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000015.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 15,
+      "frameIndex": 15
+    },
+    {
+      "name": "image_02/0000000016",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000016.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 16,
+      "frameIndex": 16
+    },
+    {
+      "name": "image_02/0000000017",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000017.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 17,
+      "frameIndex": 17
+    },
+    {
+      "name": "image_02/0000000018",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000018.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 18,
+      "frameIndex": 18
+    },
+    {
+      "name": "image_02/0000000019",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000019.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 19,
+      "frameIndex": 19
+    },
+    {
+      "name": "image_02/0000000020",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000020.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 20,
+      "frameIndex": 20
+    },
+    {
+      "name": "image_02/0000000021",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_02/0000000021.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 21,
+      "frameIndex": 21
+    },
+    {
+      "name": "image_03/0000000000",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000000.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 0,
+      "frameIndex": 0
+    },
+    {
+      "name": "image_03/0000000001",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000001.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 1,
+      "frameIndex": 1
+    },
+    {
+      "name": "image_03/0000000002",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000002.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 2,
+      "frameIndex": 2
+    },
+    {
+      "name": "image_03/0000000003",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000003.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 3,
+      "frameIndex": 3
+    },
+    {
+      "name": "image_03/0000000004",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000004.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 4,
+      "frameIndex": 4
+    },
+    {
+      "name": "image_03/0000000005",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000005.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 5,
+      "frameIndex": 5
+    },
+    {
+      "name": "image_03/0000000006",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000006.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 6,
+      "frameIndex": 6
+    },
+    {
+      "name": "image_03/0000000007",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000007.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 7,
+      "frameIndex": 7
+    },
+    {
+      "name": "image_03/0000000008",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000008.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 8,
+      "frameIndex": 8
+    },
+    {
+      "name": "image_03/0000000009",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000009.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 9,
+      "frameIndex": 9
+    },
+    {
+      "name": "image_03/0000000010",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000010.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 10,
+      "frameIndex": 10
+    },
+    {
+      "name": "image_03/0000000011",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000011.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 11,
+      "frameIndex": 11
+    },
+    {
+      "name": "image_03/0000000012",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000012.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 12,
+      "frameIndex": 12
+    },
+    {
+      "name": "image_03/0000000013",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000013.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 13,
+      "frameIndex": 13
+    },
+    {
+      "name": "image_03/0000000014",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000014.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 14,
+      "frameIndex": 14
+    },
+    {
+      "name": "image_03/0000000015",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000015.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 15,
+      "frameIndex": 15
+    },
+    {
+      "name": "image_03/0000000016",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000016.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 16,
+      "frameIndex": 16
+    },
+    {
+      "name": "image_03/0000000017",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000017.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 17,
+      "frameIndex": 17
+    },
+    {
+      "name": "image_03/0000000018",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000018.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 18,
+      "frameIndex": 18
+    },
+    {
+      "name": "image_03/0000000019",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000019.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 19,
+      "frameIndex": 19
+    },
+    {
+      "name": "image_03/0000000020",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000020.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 20,
+      "frameIndex": 20
+    },
+    {
+      "name": "image_03/0000000021",
+      "url": "https://s3-us-west-2.amazonaws.com/scalabel-public/demo/kitti/image_03/0000000021.png",
+      "videoName": null,
+      "extrinsics": null,
+      "timestamp": 21,
+      "frameIndex": 21
+    }
+  ],
+  "frameGroups": [
+    {
+      "name": "0000000000",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 0,
+      "frameIndex": 0,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000000",
+        "image_00/0000000000",
+        "image_01/0000000000",
+        "image_02/0000000000",
+        "image_03/0000000000"
+      ]
+    },
+    {
+      "name": "0000000001",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 1,
+      "frameIndex": 1,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000001",
+        "image_00/0000000001",
+        "image_01/0000000001",
+        "image_02/0000000001",
+        "image_03/0000000001"
+      ]
+    },
+    {
+      "name": "0000000002",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 2,
+      "frameIndex": 2,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000002",
+        "image_00/0000000002",
+        "image_01/0000000002",
+        "image_02/0000000002",
+        "image_03/0000000002"
+      ]
+    },
+    {
+      "name": "0000000003",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 3,
+      "frameIndex": 3,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000003",
+        "image_00/0000000003",
+        "image_01/0000000003",
+        "image_02/0000000003",
+        "image_03/0000000003"
+      ]
+    },
+    {
+      "name": "0000000004",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 4,
+      "frameIndex": 4,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000004",
+        "image_00/0000000004",
+        "image_01/0000000004",
+        "image_02/0000000004",
+        "image_03/0000000004"
+      ]
+    },
+    {
+      "name": "0000000005",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 5,
+      "frameIndex": 5,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000005",
+        "image_00/0000000005",
+        "image_01/0000000005",
+        "image_02/0000000005",
+        "image_03/0000000005"
+      ]
+    },
+    {
+      "name": "0000000006",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 6,
+      "frameIndex": 6,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000006",
+        "image_00/0000000006",
+        "image_01/0000000006",
+        "image_02/0000000006",
+        "image_03/0000000006"
+      ]
+    },
+    {
+      "name": "0000000007",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 7,
+      "frameIndex": 7,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000007",
+        "image_00/0000000007",
+        "image_01/0000000007",
+        "image_02/0000000007",
+        "image_03/0000000007"
+      ]
+    },
+    {
+      "name": "0000000008",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 8,
+      "frameIndex": 8,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000008",
+        "image_00/0000000008",
+        "image_01/0000000008",
+        "image_02/0000000008",
+        "image_03/0000000008"
+      ]
+    },
+    {
+      "name": "0000000009",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 9,
+      "frameIndex": 9,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000009",
+        "image_00/0000000009",
+        "image_01/0000000009",
+        "image_02/0000000009",
+        "image_03/0000000009"
+      ]
+    },
+    {
+      "name": "0000000010",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 10,
+      "frameIndex": 10,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000010",
+        "image_00/0000000010",
+        "image_01/0000000010",
+        "image_02/0000000010",
+        "image_03/0000000010"
+      ]
+    },
+    {
+      "name": "0000000011",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 11,
+      "frameIndex": 11,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000011",
+        "image_00/0000000011",
+        "image_01/0000000011",
+        "image_02/0000000011",
+        "image_03/0000000011"
+      ]
+    },
+    {
+      "name": "0000000012",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 12,
+      "frameIndex": 12,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000012",
+        "image_00/0000000012",
+        "image_01/0000000012",
+        "image_02/0000000012",
+        "image_03/0000000012"
+      ]
+    },
+    {
+      "name": "0000000013",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 13,
+      "frameIndex": 13,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000013",
+        "image_00/0000000013",
+        "image_01/0000000013",
+        "image_02/0000000013",
+        "image_03/0000000013"
+      ]
+    },
+    {
+      "name": "0000000014",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 14,
+      "frameIndex": 14,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000014",
+        "image_00/0000000014",
+        "image_01/0000000014",
+        "image_02/0000000014",
+        "image_03/0000000014"
+      ]
+    },
+    {
+      "name": "0000000015",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 15,
+      "frameIndex": 15,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000015",
+        "image_00/0000000015",
+        "image_01/0000000015",
+        "image_02/0000000015",
+        "image_03/0000000015"
+      ]
+    },
+    {
+      "name": "0000000016",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 16,
+      "frameIndex": 16,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000016",
+        "image_00/0000000016",
+        "image_01/0000000016",
+        "image_02/0000000016",
+        "image_03/0000000016"
+      ]
+    },
+    {
+      "name": "0000000017",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 17,
+      "frameIndex": 17,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000017",
+        "image_00/0000000017",
+        "image_01/0000000017",
+        "image_02/0000000017",
+        "image_03/0000000017"
+      ]
+    },
+    {
+      "name": "0000000018",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 18,
+      "frameIndex": 18,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000018",
+        "image_00/0000000018",
+        "image_01/0000000018",
+        "image_02/0000000018",
+        "image_03/0000000018"
+      ]
+    },
+    {
+      "name": "0000000019",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 19,
+      "frameIndex": 19,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000019",
+        "image_00/0000000019",
+        "image_01/0000000019",
+        "image_02/0000000019",
+        "image_03/0000000019"
+      ]
+    },
+    {
+      "name": "0000000020",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 20,
+      "frameIndex": 20,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000020",
+        "image_00/0000000020",
+        "image_01/0000000020",
+        "image_02/0000000020",
+        "image_03/0000000020"
+      ]
+    },
+    {
+      "name": "0000000021",
+      "url": null,
+      "videoName": null,
+      "intrinsics": null,
+      "extrinsics": null,
+      "attributes": null,
+      "timestamp": 21,
+      "frameIndex": 21,
+      "size": null,
+      "labels": null,
+      "frames": [
+        "0000000021",
+        "image_00/0000000021",
+        "image_01/0000000021",
+        "image_02/0000000021",
+        "image_03/0000000021"
+      ]
+    }
+  ]
+}

--- a/examples/kitti/kitti_sensors.json
+++ b/examples/kitti/kitti_sensors.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": 0,
+    "name": "pc0",
+    "type": "pointcloud"
+  },
+  {
+    "id": 1,
+    "name": "image0",
+    "type": "image_3d"
+  },
+  {
+    "id": 2,
+    "name": "image1",
+    "type": "image_3d"
+  },
+  {
+    "id": 3,
+    "name": "image2",
+    "type": "image_3d"
+  },
+  {
+    "id": 4,
+    "name": "image3",
+    "type": "image_3d"
+  }
+]


### PR DESCRIPTION
## Description
Visualisation example of pointclouds (converted from the default `.bin` to Scalabel-compatible `.ply`) and four corresponding images (two RGB, two grayscale) using KITTI velodyne dataset.

![image](https://user-images.githubusercontent.com/47574881/145915594-b65f7f18-8ff4-40e7-ab30-13a6626d90fb.png)
