### PR TITLE
Fix point cloud canvas not updating point cloud

### DIFF
--- a/app/src/components/point_cloud_canvas.tsx
+++ b/app/src/components/point_cloud_canvas.tsx
@@ -139,6 +139,8 @@ class PointCloudCanvas extends DrawableCanvas<Props> {
   private readonly _drawableUpdateCallback: () => void
   /** have points been set or transformed */
   private _pointsUpdated: boolean
+  /** currently selected item */
+  private _currentItem: number
   /** context of image canvas */
   private _hiddenContext: CanvasRenderingContext2D | null
   /** canvas for drawing image & getting colors */
@@ -161,6 +163,7 @@ class PointCloudCanvas extends DrawableCanvas<Props> {
     this.target = new THREE.AxesHelper(0.5)
     this.scene.add(this.target)
     this._pointsUpdated = false
+    this._currentItem = 0
     this._hiddenContext = null
     this._hiddenCanvas = document.createElement("canvas")
     this._colorScheme = null
@@ -270,6 +273,10 @@ class PointCloudCanvas extends DrawableCanvas<Props> {
     const select = state.user.select
     const item = select.item
     const sensor = this.state.user.viewerConfigs[this.props.id].sensor
+    if (item !== this._currentItem) {
+      this._currentItem = item
+      this._pointsUpdated = false
+    }
 
     const config = state.user.viewerConfigs[
       this.props.id
@@ -306,6 +313,7 @@ class PointCloudCanvas extends DrawableCanvas<Props> {
           ).data
         }
       }
+      this.updatePointCloudColors()
     }
     if (this._pointsUpdated && this._colorScheme !== config.colorScheme) {
       this._colorScheme = config.colorScheme


### PR DESCRIPTION
## Changes
- Fixes bug where point cloud canvas would not update the point cloud state when changing item

## Test
- Open any point cloud project, and navigate between items. The point cloud should update per item.