### PR TITLE
Updated formidable file path

### DIFF
--- a/app/src/server/listeners.ts
+++ b/app/src/server/listeners.ts
@@ -282,8 +282,7 @@ export class Listeners {
     for (const key of Object.keys(formFiles)) {
       const file = formFiles[key]
       if (file !== undefined && file.size !== 0) {
-        // @ts-expect-error
-        files[key] = file.path
+        files[key] = file.filepath
       }
     }
 


### PR DESCRIPTION
Fixes #447 

Updated version of Formidable changed the file path attribute from `path` to `filepath`, causing the item file(s) to be read incorrectly.