### PR TITLE
Enable hide tags by pressing T

### DIFF
--- a/app/src/components/label2d_canvas.tsx
+++ b/app/src/components/label2d_canvas.tsx
@@ -242,6 +242,7 @@ export class Label2dCanvas extends DrawableCanvas<Props> {
         this.controlContext,
         this.displayToImageRatio * UP_RES_RATIO,
         config.hideLabels,
+        config.hideLabeTags,
         mode
       )
     }

--- a/app/src/components/toolbar.tsx
+++ b/app/src/components/toolbar.tsx
@@ -93,6 +93,16 @@ export class ToolBar extends Component<Props> {
         Session.dispatch(changeViewerConfig(Session.activeViewerId, config))
         break
       }
+      case Key.T_LOW:
+      case Key.T_UP: {
+        e.preventDefault()
+        const config = {
+          ...this.state.user.viewerConfigs[Session.activeViewerId]
+        }
+        config.hideLabeTags = !config.hideLabeTags
+        Session.dispatch(changeViewerConfig(Session.activeViewerId, config))
+        break
+      }
       case Key.X_LOW: {
         if (this.state.session.mode === ModeStatus.ANNOTATING) {
           Session.dispatch(changeModeToSelecting())

--- a/app/src/drawable/2d/box2d.ts
+++ b/app/src/drawable/2d/box2d.ts
@@ -100,6 +100,7 @@ export class Box2D extends Label2D {
    * @param ratio
    * @param mode
    * @param isTrackLinking
+   * @param hideLabelTags
    * @param sessionMode
    */
   public draw(
@@ -107,6 +108,7 @@ export class Box2D extends Label2D {
     ratio: number,
     mode: DrawMode,
     isTrackLinking: boolean,
+    hideLabelTags: boolean,
     sessionMode: ModeStatus | undefined
   ): void {
     // Set proper drawing styles
@@ -148,7 +150,7 @@ export class Box2D extends Label2D {
     const rect = this._rect
     rectStyle.color = assignColor(0)
     rect.draw(context, ratio, rectStyle)
-    if (mode === DrawMode.VIEW) {
+    if (!hideLabelTags && mode === DrawMode.VIEW) {
       if (this._selected) {
         isTrackLinking = isTrackLinking && true
       } else {

--- a/app/src/drawable/2d/label2d.ts
+++ b/app/src/drawable/2d/label2d.ts
@@ -294,6 +294,7 @@ export abstract class Label2D {
    * @param {number} ratio: display to image size ratio
    * @param {DrawMode} mode
    * @param {boolean} isTrackLinking
+   * @param {boolean} hideLabelTags
    * @param {ModeStatus} sessionMode
    */
   public abstract draw(
@@ -301,6 +302,7 @@ export abstract class Label2D {
     ratio: number,
     mode: DrawMode,
     isTrackLinking: boolean,
+    hideLabelTags: boolean,
     sessionMode: ModeStatus | undefined
   ): void
 

--- a/app/src/drawable/2d/label2d_list.ts
+++ b/app/src/drawable/2d/label2d_list.ts
@@ -152,6 +152,7 @@ export class Label2DList {
    * @param {number} ratio: ratio: display to image size ratio
    * @param ratio
    * @param hideLabels
+   * @param hideLabelTags
    * @param sessionMode
    */
   public redraw(
@@ -159,6 +160,7 @@ export class Label2DList {
     controlContext: Context2D,
     ratio: number,
     hideLabels?: boolean,
+    hideLabelTags?: boolean,
     sessionMode?: ModeStatus
   ): void {
     const isTrackLinking = this._state.session.trackLinking
@@ -167,16 +169,19 @@ export class Label2DList {
         ? this._labelList.filter((label) => label.selected)
         : this._labelList
     labelsToDraw.forEach((v) =>
-      v.draw(labelContext, ratio, DrawMode.VIEW, isTrackLinking, sessionMode)
-    )
-    labelsToDraw.forEach((v) =>
-      v.draw(
-        controlContext,
-        ratio,
-        DrawMode.CONTROL,
-        isTrackLinking,
-        sessionMode
-      )
+      [
+        { ctx: labelContext, mode: DrawMode.VIEW },
+        { ctx: controlContext, mode: DrawMode.CONTROL }
+      ].forEach(({ ctx, mode }) => {
+        v.draw(
+          ctx,
+          ratio,
+          mode,
+          isTrackLinking,
+          hideLabelTags ?? false,
+          sessionMode
+        )
+      })
     )
   }
 

--- a/app/src/drawable/2d/polygon2d.ts
+++ b/app/src/drawable/2d/polygon2d.ts
@@ -117,6 +117,7 @@ export class Polygon2D extends Label2D {
    * @param ratio
    * @param mode
    * @param isTrackLinking
+   * @param hideLabelTags
    * @param sessionMode
    */
   public draw(
@@ -124,6 +125,7 @@ export class Polygon2D extends Label2D {
     ratio: number,
     mode: DrawMode,
     isTrackLinking: boolean,
+    hideLabelTags: boolean,
     sessionMode: ModeStatus | undefined
   ): void {
     const numPoints = this._points.length
@@ -279,7 +281,11 @@ export class Polygon2D extends Label2D {
     if (this._label !== null) {
       checked = this._label.checked
     }
-    if (mode === DrawMode.VIEW && this._state !== Polygon2DState.DRAW) {
+    if (
+      !hideLabelTags &&
+      mode === DrawMode.VIEW &&
+      this._state !== Polygon2DState.DRAW
+    ) {
       if (this._selected) {
         isTrackLinking = isTrackLinking && true
       } else {

--- a/app/src/functional/states.ts
+++ b/app/src/functional/states.ts
@@ -303,7 +303,8 @@ export function makeImageViewerConfig(
     sensor,
     pane,
     synchronized: false,
-    hideLabels: false
+    hideLabels: false,
+    hideLabeTags: false
   }
 }
 
@@ -330,6 +331,7 @@ export function makePointCloudViewerConfig(
     pane,
     synchronized: false,
     hideLabels: false,
+    hideLabeTags: false,
     cameraRotateDir: false,
     colorScheme: ColorSchemeType.HEIGHT,
     cameraTransformed: false

--- a/app/src/types/state.ts
+++ b/app/src/types/state.ts
@@ -201,6 +201,8 @@ export interface ViewerConfigType {
   synchronized: boolean
   /** whether to hide non-selected labels */
   hideLabels: boolean
+  /** whether to hide label tags */
+  hideLabeTags: boolean
 }
 
 export interface ImageViewerConfigType extends ViewerConfigType {

--- a/doc/src/keyboard.rst
+++ b/doc/src/keyboard.rst
@@ -11,6 +11,8 @@ General
 +-----------+----------------------------------------------+
 | h         | Hide all the labels except the selected one  |
 +-----------+----------------------------------------------+
+| t         | Hide tags of all labels                      |
++-----------+----------------------------------------------+
 | x         | Switch between ANNOTATING and SELECTING mode |
 +-----------+----------------------------------------------+
 | →         | Right arrow key to go to the next item       |


### PR DESCRIPTION
# Summary

- Enable hide/show tags by pressing `t`.
- Resolve issue #477.