### PR TITLE
Ignore type for include and exclude

### DIFF
--- a/scalabel/eval/boundary.py
+++ b/scalabel/eval/boundary.py
@@ -87,7 +87,7 @@ class BoundaryResult(Result):
         """Convert data into a flattened dict as the summary."""
         summary_dict: Dict[str, Union[int, float]] = {}
         for metric, scores_list in self.dict(
-            include=include or set(), exclude=exclude or set()
+            include=include, exclude=exclude  # type: ignore
         ).items():
             for category, score in scores_list[-2].items():
                 summary_dict[f"{metric}/{category}"] = score

--- a/scalabel/eval/pan_seg.py
+++ b/scalabel/eval/pan_seg.py
@@ -76,7 +76,7 @@ class PanSegResult(Result):
         """Convert the pan_seg data into a flattened dict as the summary."""
         summary_dict: Dict[str, Union[int, float]] = {}
         for metric, scores_list in self.dict(
-            include=include or set(), exclude=exclude or set()
+            include=include, exclude=exclude  # type: ignore
         ).items():
             summary_dict[f"{metric}/{STUFF}"] = scores_list[1][STUFF]
             summary_dict[f"{metric}/{THING}"] = scores_list[1][THING]

--- a/scalabel/eval/result.py
+++ b/scalabel/eval/result.py
@@ -99,7 +99,7 @@ class Result(BaseModel):
         """
         frame_dict: Dict[str, Scores] = defaultdict(dict)
         for metric, scores_list in self.dict(
-            include=include or set(), exclude=exclude or set()
+            include=include, exclude=exclude  # type: ignore
         ).items():
             if not isinstance(scores_list, list):
                 continue
@@ -157,7 +157,7 @@ class Result(BaseModel):
         """
         summary_dict: Dict[str, Union[int, float]] = {}
         for metric, scores_list in self.dict(
-            include=include or set(), exclude=exclude or set()
+            include=include, exclude=exclude   # type: ignore
         ).items():
             if not isinstance(scores_list, list):
                 summary_dict[metric] = scores_list

--- a/scalabel/eval/sem_seg.py
+++ b/scalabel/eval/sem_seg.py
@@ -46,7 +46,7 @@ class SegResult(Result):
         """Convert the seg result into a flattened dict as the summary."""
         summary_dict: Dict[str, Union[int, float]] = {}
         for metric, scores_list in self.dict(
-            include=include or set(), exclude=exclude or set()
+            include=include, exclude=exclude   # type: ignore
         ).items():
             if not isinstance(scores_list, list):
                 summary_dict[metric] = scores_list

--- a/scalabel/eval/tagging.py
+++ b/scalabel/eval/tagging.py
@@ -240,7 +240,7 @@ class TaggingResult(Result):
         """Convert tagging results into a flattened dict as the summary."""
         summary_dict: Dict[str, Union[int, float]] = {}
         for metric, scores_list in self.dict(
-            include=include or set(), exclude=exclude or set()
+            include=include, exclude=exclude   # type: ignore
         ).items():
             for category, score in scores_list[-2].items():
                 summary_dict[f"{metric}/{category}"] = score


### PR DESCRIPTION
Pydantic expects `include: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None` to be passed into `dict()`, but we are passing in `include: Optional[AbstractSet[str]]`. Technically, we have the correct type, because the value is allowed to be `None`. Since this issue is part of Pydantic, we will ignore them for now.